### PR TITLE
Fix code scanning alert no. 19: Size computation for allocation may overflow

### DIFF
--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -31,6 +31,9 @@ func EncryptData(data []byte, key []byte) (string, error) {
 		return "", err
 	}
 
+	if len(data) > (1<<31 - 1 - aes.BlockSize) {
+		return "", errors.New("data too large to encrypt")
+	}
 	ciphertext := make([]byte, aes.BlockSize+len(data))
 	copy(ciphertext[:aes.BlockSize], iv)
 


### PR DESCRIPTION
Fixes [https://github.com/kek-Sec/GopherDrop/security/code-scanning/19](https://github.com/kek-Sec/GopherDrop/security/code-scanning/19)

To fix the problem, we need to ensure that the size computation for the allocation does not overflow. This can be achieved by adding a check to ensure that the length of the data does not exceed a safe limit before performing the arithmetic operation. We will add a check to ensure that the length of the data is within a safe range before proceeding with the allocation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
