### PR TITLE
feat: modern landing page with gamified server-ledger stats dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.1.0]
+
+### Added
+- **Gamified server stats dashboard** on the landing page — a live "server ledger" beside the create form showing lifetime KPIs (Secrets Delivered, Text Secrets, Files Shared, Data Encrypted) and a live "Held right now" count.
+  - The hero "Secrets delivered" figure **ticks +1 with a count-up animation** the moment you create a secret.
+  - A 30-day stacked activity chart (text vs. file), a text/file split bar, and a milestone progress meter — all hand-rolled inline SVG (no charting-library dependency, keeps the bundle lean).
+- New public, aggregate-only **`GET /stats`** endpoint (30s in-memory cache, no per-secret data ever exposed). Toggle with the `STATS_ENABLED` env var (default `true`).
+- Lifetime counters (`stat_counters`) and per-day activity (`stat_days`) tables. Counters are **monotonic**: incremented at creation and never decremented by expiry or one-time retrieval, so totals are honest despite secrets being ephemeral. A `since` timestamp keeps the "lifetime" figure honest on pre-existing installs.
+
+### Changed
+- Modernized the landing page: new "Share secrets that vanish." hero, refined two-column layout (form + ledger), Space Grotesk display type, and a tasteful, `prefers-reduced-motion`-aware motion budget.
+- Extracted the post-create success panel into a reusable `SecretResult` component.
+- Send creation now verifies the database write succeeded before returning a link (previously the insert error was ignored).
+
+### Privacy
+- **Removed all third-party CDN requests on page load.** Inter and Space Grotesk fonts are now self-hosted via `@fontsource`, and the `animate.css` CDN link was dropped (its handful of animations are re-implemented locally). A privacy tool no longer phones home.
+
 ## [10.0.10]
 
 ### Added

--- a/Readme.md
+++ b/Readme.md
@@ -128,6 +128,7 @@ MAX_FILE_SIZE=10485760
 | `LISTEN_ADDR`    | API listen address              | `:8080`                             |
 | `STORAGE_PATH`   | Path for storing uploaded files | `/app/storage`                      |
 | `MAX_FILE_SIZE`  | Maximum file size in bytes      | `10485760` (10 MB)                  |
+| `STATS_ENABLED`  | Expose the public `/stats` endpoint and landing-page stats dashboard | `true`         |
 
 ### **Build Arguments**
 
@@ -153,6 +154,7 @@ MAX_FILE_SIZE=10485760
 | `POST` | `/send/file`       | Create a file send (curl-friendly)       |
 | `GET`  | `/send/:id`        | Retrieve a send by its hash              |
 | `GET`  | `/send/:id/check`  | Check if a send requires a password      |
+| `GET`  | `/stats`           | Public aggregate stats (no per-secret data); disable via `STATS_ENABLED=false` |
 
 ### **curl Examples**
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,6 +24,17 @@ func main() {
 	// Initialize database
 	db := database.InitDB(cfg)
 	db.AutoMigrate(&models.Send{})
+	db.AutoMigrate(&models.StatCounters{})
+	db.AutoMigrate(&models.StatDay{})
+
+	// Seed the lifetime stat counters row if it doesn't exist yet. This row
+	// is the single source of truth for the "since" timestamp reported by
+	// GET /stats, and must never be deleted or decremented.
+	var counters models.StatCounters
+	if db.Where("id = ?", 1).First(&counters).RecordNotFound() {
+		db.Create(&models.StatCounters{ID: 1, Since: time.Now()})
+	}
+
 	go database.CleanupExpired(db)
 
 	// Setup router

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,19 +4,21 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 // Config holds all environment-based configuration.
 type Config struct {
-	DBHost      string
-	DBUser      string
-	DBPass      string
-	DBName      string
-	DBSSLMode   string
-	SecretKey   string
-	ListenAddr  string
-	StoragePath string
-	MaxFileSize int64
+	DBHost       string
+	DBUser       string
+	DBPass       string
+	DBName       string
+	DBSSLMode    string
+	SecretKey    string
+	ListenAddr   string
+	StoragePath  string
+	MaxFileSize  int64
+	StatsEnabled bool
 }
 
 // LoadConfig returns a Config object populated from environment variables.
@@ -51,6 +53,9 @@ func LoadConfig() Config {
 			cfg.MaxFileSize = size
 		}
 	}
+
+	statsEnabledStr := strings.ToLower(strings.TrimSpace(os.Getenv("STATS_ENABLED")))
+	cfg.StatsEnabled = statsEnabledStr != "false" && statsEnabledStr != "0"
 
 	return cfg
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -120,7 +120,12 @@ func createSendWithType(cfg config.Config, db *gorm.DB, forcedType string) gin.H
 				OneTime:   oneTime,
 				ExpiresAt: expiresAt,
 			}
-			db.Create(&s)
+			if err := db.Create(&s).Error; err != nil {
+				log.Println("Error saving text send:", err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to save send"})
+				return
+			}
+			recordSendStats(db, "text", int64(len(text)))
 			log.Println("Text send created successfully with hash:", hash)
 			c.JSON(http.StatusOK, gin.H{"hash": s.Hash})
 			return
@@ -176,7 +181,12 @@ func createSendWithType(cfg config.Config, db *gorm.DB, forcedType string) gin.H
 				OneTime:   oneTime,
 				ExpiresAt: expiresAt,
 			}
-			db.Create(&s)
+			if err := db.Create(&s).Error; err != nil {
+				log.Println("Error saving file send:", err)
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Failed to save send"})
+				return
+			}
+			recordSendStats(db, "file", int64(len(fileData)))
 			log.Println("File send created successfully with hash:", hash)
 			c.JSON(http.StatusOK, gin.H{"hash": s.Hash})
 			return

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -23,6 +24,10 @@ func setupTestDB() *gorm.DB {
 		panic(err)
 	}
 	db.AutoMigrate(&models.Send{})
+	db.AutoMigrate(&models.StatCounters{})
+	db.AutoMigrate(&models.StatDay{})
+	db.Create(&models.StatCounters{ID: 1, Since: time.Now()})
+	resetStatsCacheForTests()
 	return db
 }
 
@@ -33,6 +38,7 @@ func setupTestRouter(cfg config.Config, db *gorm.DB) *gin.Engine {
 	r.POST("/send/file", CreateFileSend(cfg, db))
 	r.GET("/send/:id", GetSend(cfg, db))
 	r.GET("/send/:id/check", CheckPasswordProtection(db))
+	r.GET("/stats", GetStats(db))
 	return r
 }
 
@@ -242,5 +248,238 @@ func TestExpiredSend(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 got %d", w.Code)
+	}
+}
+
+func getStatCounters(db *gorm.DB) models.StatCounters {
+	var c models.StatCounters
+	db.Where("id = ?", 1).First(&c)
+	return c
+}
+
+func TestCreateTextSendIncrementsStats(t *testing.T) {
+	db := setupTestDB()
+	cfg := config.Config{
+		SecretKey:   "supersecretkeysupersecretkey32",
+		MaxFileSize: 1024 * 1024,
+	}
+	r := setupTestRouter(cfg, db)
+
+	before := getStatCounters(db)
+
+	text := "This is a test message."
+	body, contentType := createMultipartRequest("data", text)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/send", body)
+	req.Header.Set("Content-Type", contentType)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+
+	after := getStatCounters(db)
+
+	if after.TotalSends != before.TotalSends+1 {
+		t.Fatalf("expected total_sends to increment by 1, got before=%d after=%d", before.TotalSends, after.TotalSends)
+	}
+	if after.TextSends != before.TextSends+1 {
+		t.Fatalf("expected text_sends to increment by 1, got before=%d after=%d", before.TextSends, after.TextSends)
+	}
+	if after.FileSends != before.FileSends {
+		t.Fatalf("expected file_sends to stay unchanged, got before=%d after=%d", before.FileSends, after.FileSends)
+	}
+	if after.TotalBytes != before.TotalBytes+int64(len(text)) {
+		t.Fatalf("expected total_bytes to increment by %d, got before=%d after=%d", len(text), before.TotalBytes, after.TotalBytes)
+	}
+}
+
+func TestCreateFileSendIncrementsStats(t *testing.T) {
+	db := setupTestDB()
+	cfg := config.Config{
+		SecretKey:   "supersecretkeysupersecretkey32",
+		MaxFileSize: 1024 * 1024,
+	}
+	r := setupTestRouter(cfg, db)
+
+	before := getStatCounters(db)
+
+	content := "some file contents"
+	body, contentType := createMultipartFileRequest("file", "test.txt", content)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/send", body)
+	req.Header.Set("Content-Type", contentType)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+
+	after := getStatCounters(db)
+
+	if after.TotalSends != before.TotalSends+1 {
+		t.Fatalf("expected total_sends to increment by 1, got before=%d after=%d", before.TotalSends, after.TotalSends)
+	}
+	if after.FileSends != before.FileSends+1 {
+		t.Fatalf("expected file_sends to increment by 1, got before=%d after=%d", before.FileSends, after.FileSends)
+	}
+	if after.TextSends != before.TextSends {
+		t.Fatalf("expected text_sends to stay unchanged, got before=%d after=%d", before.TextSends, after.TextSends)
+	}
+	if after.TotalBytes != before.TotalBytes+int64(len(content)) {
+		t.Fatalf("expected total_bytes to increment by %d, got before=%d after=%d", len(content), before.TotalBytes, after.TotalBytes)
+	}
+}
+
+func TestDeletingSendDoesNotDecrementStats(t *testing.T) {
+	db := setupTestDB()
+	cfg := config.Config{
+		SecretKey:   "supersecretkeysupersecretkey32",
+		MaxFileSize: 1024 * 1024,
+	}
+	r := setupTestRouter(cfg, db)
+
+	body, contentType := createMultipartRequest("data", "some data to delete")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/send", body)
+	req.Header.Set("Content-Type", contentType)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	hash := resp["hash"]
+
+	afterCreate := getStatCounters(db)
+
+	// Force expiry and fetch, which triggers deleteSendAndFile.
+	db.Model(&models.Send{}).Where("hash = ?", hash).UpdateColumn("expires_at", time.Now().Add(-1*time.Hour))
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/send/"+hash, nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for expired send, got %d", w.Code)
+	}
+
+	// Confirm the send was actually deleted from the database.
+	var count int
+	db.Model(&models.Send{}).Where("hash = ?", hash).Count(&count)
+	if count != 0 {
+		t.Fatalf("expected send to be deleted, but it still exists")
+	}
+
+	afterDelete := getStatCounters(db)
+
+	if afterDelete.TotalSends != afterCreate.TotalSends {
+		t.Fatalf("expected total_sends to remain unchanged after delete, before=%d after=%d", afterCreate.TotalSends, afterDelete.TotalSends)
+	}
+	if afterDelete.TextSends != afterCreate.TextSends {
+		t.Fatalf("expected text_sends to remain unchanged after delete, before=%d after=%d", afterCreate.TextSends, afterDelete.TextSends)
+	}
+	if afterDelete.TotalBytes != afterCreate.TotalBytes {
+		t.Fatalf("expected total_bytes to remain unchanged after delete, before=%d after=%d", afterCreate.TotalBytes, afterDelete.TotalBytes)
+	}
+}
+
+func TestGetStatsShape(t *testing.T) {
+	db := setupTestDB()
+	cfg := config.Config{
+		SecretKey:   "supersecretkeysupersecretkey32",
+		MaxFileSize: 1024 * 1024,
+	}
+	r := setupTestRouter(cfg, db)
+
+	// One active send, one already-expired send (should not count as active).
+	db.Create(&models.Send{
+		Hash:      "activehash",
+		Type:      "text",
+		Data:      "data",
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	db.Create(&models.Send{
+		Hash:      "expiredstatshash",
+		Type:      "text",
+		Data:      "data",
+		ExpiresAt: time.Now().Add(-time.Hour),
+	})
+
+	body, contentType := createMultipartRequest("data", "hello world")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/send", body)
+	req.Header.Set("Content-Type", contentType)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 creating send, got %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/stats", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+
+	var stats struct {
+		Lifetime struct {
+			Total int64 `json:"total"`
+			Texts int64 `json:"texts"`
+			Files int64 `json:"files"`
+			Bytes int64 `json:"bytes"`
+		} `json:"lifetime"`
+		Active struct {
+			Total int64 `json:"total"`
+		} `json:"active"`
+		Daily []struct {
+			Date  string `json:"date"`
+			Texts int64  `json:"texts"`
+			Files int64  `json:"files"`
+			Bytes int64  `json:"bytes"`
+		} `json:"daily"`
+		Since string `json:"since"`
+	}
+
+	if err := json.Unmarshal(w.Body.Bytes(), &stats); err != nil {
+		t.Fatalf("failed to parse /stats response: %v", err)
+	}
+
+	if stats.Lifetime.Total != 1 {
+		t.Fatalf("expected lifetime.total=1, got %d", stats.Lifetime.Total)
+	}
+	if stats.Lifetime.Texts != 1 {
+		t.Fatalf("expected lifetime.texts=1, got %d", stats.Lifetime.Texts)
+	}
+	if stats.Lifetime.Bytes != int64(len("hello world")) {
+		t.Fatalf("expected lifetime.bytes=%d, got %d", len("hello world"), stats.Lifetime.Bytes)
+	}
+	// Two pre-seeded sends (1 active + 1 expired), only the active one, plus
+	// the newly created send, should count towards active.total.
+	if stats.Active.Total != 2 {
+		t.Fatalf("expected active.total=2, got %d", stats.Active.Total)
+	}
+	if len(stats.Daily) != 30 {
+		t.Fatalf("expected exactly 30 daily entries, got %d", len(stats.Daily))
+	}
+	todayKey := time.Now().UTC().Format("2006-01-02")
+	if stats.Daily[len(stats.Daily)-1].Date != todayKey {
+		t.Fatalf("expected last daily entry to be today (%s), got %s", todayKey, stats.Daily[len(stats.Daily)-1].Date)
+	}
+	if stats.Daily[len(stats.Daily)-1].Texts != 1 {
+		t.Fatalf("expected today's daily texts=1, got %d", stats.Daily[len(stats.Daily)-1].Texts)
+	}
+	if stats.Since == "" {
+		t.Fatalf("expected since to be a non-empty RFC3339 timestamp")
+	}
+	if _, err := time.Parse(time.RFC3339, stats.Since); err != nil {
+		t.Fatalf("expected since to be RFC3339, got %q: %v", stats.Since, err)
 	}
 }

--- a/internal/handlers/stats.go
+++ b/internal/handlers/stats.go
@@ -1,0 +1,196 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+
+	"github.com/kek-Sec/gopherdrop/internal/models"
+)
+
+// statsCacheTTL controls how long a built /stats payload is reused before
+// being recomputed. This keeps the endpoint effectively free to call and
+// removes the need for a rate limiter on it.
+const statsCacheTTL = 30 * time.Second
+
+var (
+	statsCacheMu      sync.RWMutex
+	statsCacheAt      time.Time
+	statsCacheDB      *gorm.DB
+	statsCachePayload gin.H
+)
+
+// dailyStat represents a single zero-filled day in the daily stats series.
+type dailyStat struct {
+	Date  string `json:"date"`
+	Texts int64  `json:"texts"`
+	Files int64  `json:"files"`
+	Bytes int64  `json:"bytes"`
+}
+
+// recordSendStats best-effort increments the lifetime and daily stat
+// counters for a newly created send. It is intentionally isolated from the
+// request lifecycle: it never returns an error and must never influence the
+// HTTP response for send creation. Counters are monotonic and must never be
+// touched anywhere on the delete/expiry paths.
+//
+// It runs inline (synchronously) in the create handler rather than in a
+// goroutine: the create endpoint is rate-limited to ~1 req/s (see
+// routes.limiter), so single-row write contention on the two hot rows below is
+// a non-issue in practice, and staying synchronous keeps the in-memory sqlite
+// test DB deterministic. Both statements are upserts so they self-heal if the
+// startup seed row is ever missing (fresh/reset external DB).
+func recordSendStats(db *gorm.DB, stype string, payloadBytes int64) {
+	if db == nil {
+		return
+	}
+
+	var textInc, fileInc int64
+	switch stype {
+	case "text":
+		textInc = 1
+	case "file":
+		fileInc = 1
+	}
+
+	if err := db.Exec(
+		`INSERT INTO stat_counters (id, total_sends, text_sends, file_sends, total_bytes, since)
+		 VALUES (1, 1, ?, ?, ?, ?)
+		 ON CONFLICT(id) DO UPDATE SET total_sends = stat_counters.total_sends + 1, text_sends = stat_counters.text_sends + ?, file_sends = stat_counters.file_sends + ?, total_bytes = stat_counters.total_bytes + ?`,
+		textInc, fileInc, payloadBytes, time.Now().UTC(),
+		textInc, fileInc, payloadBytes,
+	).Error; err != nil {
+		log.Println("stats: failed to update stat_counters:", err)
+	}
+
+	day := time.Now().UTC().Format("2006-01-02")
+	if err := db.Exec(
+		`INSERT INTO stat_days (day, texts, files, bytes) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(day) DO UPDATE SET texts = stat_days.texts + ?, files = stat_days.files + ?, bytes = stat_days.bytes + ?`,
+		day, textInc, fileInc, payloadBytes,
+		textInc, fileInc, payloadBytes,
+	).Error; err != nil {
+		log.Println("stats: failed to update stat_days:", err)
+	}
+}
+
+// GetStats returns a public, aggregate-only, cached snapshot of lifetime and
+// recent activity statistics.
+func GetStats(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		payload, err := buildStatsPayload(db)
+		if err != nil {
+			log.Println("stats: failed to build stats payload:", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load stats"})
+			return
+		}
+		c.JSON(http.StatusOK, payload)
+	}
+}
+
+func buildStatsPayload(db *gorm.DB) (gin.H, error) {
+	if cached, ok := getCachedStats(db); ok {
+		return cached, nil
+	}
+
+	statsCacheMu.Lock()
+	defer statsCacheMu.Unlock()
+
+	// Re-check under the write lock in case another goroutine already
+	// rebuilt the cache while we were waiting.
+	if statsCacheDB == db && time.Since(statsCacheAt) < statsCacheTTL && statsCachePayload != nil {
+		return statsCachePayload, nil
+	}
+
+	var counters models.StatCounters
+	if db.Where("id = ?", 1).First(&counters).RecordNotFound() {
+		counters = models.StatCounters{ID: 1, Since: time.Now()}
+	}
+
+	var activeTotal int64
+	if err := db.Model(&models.Send{}).Where("expires_at > ?", time.Now()).Count(&activeTotal).Error; err != nil {
+		return nil, err
+	}
+
+	daily, err := buildDailySeries(db)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := gin.H{
+		"lifetime": gin.H{
+			"total": counters.TotalSends,
+			"texts": counters.TextSends,
+			"files": counters.FileSends,
+			"bytes": counters.TotalBytes,
+		},
+		"active": gin.H{
+			"total": activeTotal,
+		},
+		"daily": daily,
+		"since": counters.Since.UTC().Format(time.RFC3339),
+	}
+
+	statsCacheDB = db
+	statsCachePayload = payload
+	statsCacheAt = time.Now()
+
+	return payload, nil
+}
+
+// resetStatsCacheForTests clears the in-memory stats cache. Production code
+// never needs to call this; it exists purely so tests that spin up a fresh
+// in-memory DB per test case aren't at the mercy of Go potentially reusing a
+// prior *gorm.DB's memory address for the cache-identity check below.
+func resetStatsCacheForTests() {
+	statsCacheMu.Lock()
+	defer statsCacheMu.Unlock()
+	statsCacheDB = nil
+	statsCacheAt = time.Time{}
+	statsCachePayload = nil
+}
+
+func getCachedStats(db *gorm.DB) (gin.H, bool) {
+	statsCacheMu.RLock()
+	defer statsCacheMu.RUnlock()
+
+	if statsCacheDB == db && time.Since(statsCacheAt) < statsCacheTTL && statsCachePayload != nil {
+		return statsCachePayload, true
+	}
+	return nil, false
+}
+
+// buildDailySeries returns exactly 30 zero-filled daily entries, oldest
+// first, covering the last 30 UTC days ending today.
+func buildDailySeries(db *gorm.DB) ([]dailyStat, error) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	windowStart := today.AddDate(0, 0, -29)
+
+	// Bound the scan to the visible window. Days are stored as ISO "YYYY-MM-DD"
+	// so a lexicographic >= comparison is also chronological.
+	var rows []models.StatDay
+	if err := db.Where("day >= ?", windowStart.Format("2006-01-02")).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	byDay := make(map[string]models.StatDay, len(rows))
+	for _, r := range rows {
+		byDay[r.Day.UTC().Format("2006-01-02")] = r
+	}
+
+	daily := make([]dailyStat, 0, 30)
+	for i := 0; i < 30; i++ {
+		key := windowStart.AddDate(0, 0, i).Format("2006-01-02")
+		if row, ok := byDay[key]; ok {
+			daily = append(daily, dailyStat{Date: key, Texts: row.Texts, Files: row.Files, Bytes: row.Bytes})
+		} else {
+			daily = append(daily, dailyStat{Date: key})
+		}
+	}
+
+	return daily, nil
+}

--- a/internal/models/stats.go
+++ b/internal/models/stats.go
@@ -1,0 +1,26 @@
+package models
+
+import "time"
+
+// StatCounters holds monotonic lifetime counters for the stats feature.
+// There is always exactly one row, with ID=1. These counters are only ever
+// incremented at secret-creation time and must NEVER be decremented on
+// delete/expiry.
+type StatCounters struct {
+	ID         uint `gorm:"primary_key"`
+	TotalSends int64
+	TextSends  int64
+	FileSends  int64
+	TotalBytes int64
+	Since      time.Time
+}
+
+// StatDay holds per-UTC-day aggregate counters used to build the daily
+// stats series. Rows are upserted at secret-creation time and never
+// decremented.
+type StatDay struct {
+	Day   time.Time `gorm:"primary_key;type:date"`
+	Texts int64
+	Files int64
+	Bytes int64
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -47,5 +47,11 @@ func SetupRouter(cfg config.Config, db *gorm.DB) *gin.Engine {
 	r.GET("/send/:id", handlers.GetSend(cfg, db))
 	r.GET("/send/:id/check", handlers.CheckPasswordProtection(db))
 
+	// Public, cached, aggregate-only stats endpoint. No rate limiter needed
+	// since responses are served from an in-memory cache.
+	if cfg.StatsEnabled {
+		r.GET("/stats", handlers.GetStats(db))
+	}
+
 	return r
 }

--- a/internal/routes/routes_test.go
+++ b/internal/routes/routes_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -27,6 +28,13 @@ func setupTestDB() *gorm.DB {
 	if err := db.AutoMigrate(&models.Send{}).Error; err != nil {
 		panic("Failed to migrate database: " + err.Error())
 	}
+	if err := db.AutoMigrate(&models.StatCounters{}).Error; err != nil {
+		panic("Failed to migrate database: " + err.Error())
+	}
+	if err := db.AutoMigrate(&models.StatDay{}).Error; err != nil {
+		panic("Failed to migrate database: " + err.Error())
+	}
+	db.Create(&models.StatCounters{ID: 1, Since: time.Now()})
 
 	// Insert a test record
 	send := models.Send{
@@ -45,8 +53,9 @@ func setupTestDB() *gorm.DB {
 func setupTestRouter() *gin.Engine {
 	limiter = rate.NewLimiter(1, 6)
 	cfg := config.Config{
-		SecretKey:   "supersecretkey",
-		MaxFileSize: 1024 * 1024,
+		SecretKey:    "supersecretkey",
+		MaxFileSize:  1024 * 1024,
+		StatsEnabled: true,
 	}
 	db := setupTestDB()
 	return SetupRouter(cfg, db)
@@ -66,6 +75,7 @@ func TestRoutesExist(t *testing.T) {
 		{"POST", "/send/file", "test file payload", http.StatusBadRequest},
 		{"GET", "/send/testhash", "", http.StatusNotFound},
 		{"GET", "/send/testhash/check", "", http.StatusNotFound},
+		{"GET", "/stats", "", http.StatusOK},
 	}
 
 	for _, tt := range tests {
@@ -129,4 +139,47 @@ func TestRateLimiter(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusTooManyRequests, w.Code, "7th request should be rate limited")
+}
+
+func TestStatsRouteDisabledWhenConfigured(t *testing.T) {
+	limiter = rate.NewLimiter(1, 6)
+	cfg := config.Config{
+		SecretKey:    "supersecretkey",
+		MaxFileSize:  1024 * 1024,
+		StatsEnabled: false,
+	}
+	db := setupTestDB()
+	router := SetupRouter(cfg, db)
+
+	req := httptest.NewRequest("GET", "/stats", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code, "/stats should not be registered when StatsEnabled is false")
+}
+
+func TestStatsEndpointShape(t *testing.T) {
+	router := setupTestRouter()
+
+	req := httptest.NewRequest("GET", "/stats", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to parse /stats response: %v", err)
+	}
+
+	assert.Contains(t, body, "lifetime")
+	assert.Contains(t, body, "active")
+	assert.Contains(t, body, "daily")
+	assert.Contains(t, body, "since")
+
+	daily, ok := body["daily"].([]interface{})
+	if !ok {
+		t.Fatalf("expected daily to be an array")
+	}
+	assert.Equal(t, 30, len(daily), "expected exactly 30 daily entries")
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,10 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
-    />
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -26,9 +22,6 @@
     <!-- Preload critical assets -->
     <link rel="preload" href="/src/main.js" as="script" />
     <link rel="preload" href="/src/assets/Images/banner.png" as="image" />
-
-    <!-- Stylesheets -->
-    <link rel="stylesheet" href="/src/assets/styles/main.css" />
 
     <!-- Main JavaScript -->
     <script type="module" src="/src/main.js"></script>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,8 @@
             "name": "gopherdrop-ui",
             "version": "1.0.1",
             "dependencies": {
+                "@fontsource-variable/inter": "^5.1.0",
+                "@fontsource-variable/space-grotesk": "^5.0.0",
                 "@mdi/font": "^7.4.47",
                 "vite-plugin-vuetify": "^1.0.1",
                 "vue": "^3.3.4",
@@ -389,6 +391,24 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@fontsource-variable/inter": {
+            "version": "5.2.8",
+            "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+            "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+            "license": "OFL-1.1",
+            "funding": {
+                "url": "https://github.com/sponsors/ayuhito"
+            }
+        },
+        "node_modules/@fontsource-variable/space-grotesk": {
+            "version": "5.2.10",
+            "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.2.10.tgz",
+            "integrity": "sha512-yJQO/o35/hAP3CFnpdFTwQku2yzJOae2HIpBmqkOVoxhhXJaQP3g+b6Jrz7u+eI7A5ZdCIf88uMWpBJdFiGr5w==",
+            "license": "OFL-1.1",
+            "funding": {
+                "url": "https://github.com/sponsors/ayuhito"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,8 @@
         "preview": "vite preview"
     },
     "dependencies": {
+        "@fontsource-variable/inter": "^5.1.0",
+        "@fontsource-variable/space-grotesk": "^5.0.0",
         "@mdi/font": "^7.4.47",
         "vite-plugin-vuetify": "^1.0.1",
         "vue": "^3.3.4",

--- a/ui/src/assets/style.css
+++ b/ui/src/assets/style.css
@@ -1,12 +1,11 @@
 /**
  * Global styles for responsive and clean layout.
  */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
 
 html, body {
     margin: 0;
     padding: 0;
-    font-family: 'Inter', Arial, sans-serif;
+    font-family: "Inter Variable", Inter, Arial, sans-serif;
     color: #333;
     background: #f4f4f9; /* Fallback background */
 }
@@ -34,5 +33,82 @@ a:hover {
 @media (max-width: 600px) {
     main, header {
       padding: 0.5rem;
+    }
+}
+
+/* Display / headline typeface for headlines, eyebrows, hero figures */
+.font-display {
+    font-family: "Space Grotesk Variable", "Space Grotesk", sans-serif;
+}
+
+/* Tabular figures for aligned numeric columns */
+.tabular-nums {
+    font-variant-numeric: tabular-nums;
+}
+
+/*
+ * Local re-implementation of the handful of animate.css classes the app
+ * uses, so pages keep working without loading the CDN (privacy: no
+ * external requests on page load).
+ */
+@keyframes gd-fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes gd-pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+    100% { transform: scale(1); }
+}
+
+@keyframes gd-bounceIn {
+    0% { opacity: 0; transform: scale(0.9); }
+    50% { opacity: 1; transform: scale(1.03); }
+    70% { transform: scale(0.98); }
+    100% { transform: scale(1); }
+}
+
+.animate__animated {
+    animation-duration: .8s;
+    animation-fill-mode: both;
+}
+
+.animate__fadeIn {
+    animation-name: gd-fadeIn;
+}
+
+.animate__pulse {
+    animation-name: gd-pulse;
+}
+
+.animate__bounceIn {
+    animation-name: gd-bounceIn;
+}
+
+/* Local motion keyframes for the revamp */
+@keyframes gd-rise {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes gd-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.gd-rise {
+    animation: gd-rise 300ms ease-out both;
+}
+
+.gd-fade-in {
+    animation: gd-fade-in 300ms ease-out both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .animate__animated,
+    .gd-rise,
+    .gd-fade-in {
+        animation: none !important;
     }
 }

--- a/ui/src/components/SecretResult.vue
+++ b/ui/src/components/SecretResult.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-alert type="success" class="mt-6 animate__animated animate__fadeIn" variant="tonal">
+    <div class="text-h6 mb-2">Secret Created!</div>
+    <p>Share this link to view the secret:</p>
+    <div class="d-flex align-center mt-2 pa-2" style="background-color: rgba(var(--v-theme-on-surface), 0.05); border-radius: 8px;">
+      <span class="mr-2 text-truncate">{{ link }}</span>
+      <v-spacer></v-spacer>
+      <v-tooltip text="Copy Link to Clipboard">
+        <template v-slot:activator="{ props }">
+          <v-btn icon v-bind="props" @click="copyLink">
+            <v-icon>mdi-content-copy</v-icon>
+          </v-btn>
+        </template>
+      </v-tooltip>
+    </div>
+
+    <v-btn color="success" variant="outlined" class="mt-4" @click="$emit('create-another')">
+      Create another
+    </v-btn>
+
+    <v-snackbar v-model="snackbar" timeout="2000" color="success">
+      Link copied to clipboard!
+    </v-snackbar>
+  </v-alert>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const props = defineProps({
+  link: { type: String, required: true },
+});
+
+defineEmits(['create-another']);
+
+const snackbar = ref(false);
+
+function copyLink() {
+  navigator.clipboard.writeText(props.link);
+  snackbar.value = true;
+}
+</script>

--- a/ui/src/components/stats/ActivityChart.vue
+++ b/ui/src/components/stats/ActivityChart.vue
@@ -1,0 +1,327 @@
+<template>
+  <div class="activity-chart" ref="wrapRef">
+    <svg
+      class="activity-chart__svg"
+      :viewBox="`0 0 ${viewBoxWidth} ${viewBoxHeight}`"
+      preserveAspectRatio="none"
+      role="img"
+      :aria-label="ariaLabel"
+    >
+      <!-- gridlines -->
+      <g class="activity-chart__grid">
+        <line
+          v-for="(tick, i) in ticks"
+          :key="`grid-${i}`"
+          :x1="leftPad"
+          :x2="viewBoxWidth - rightPad"
+          :y1="yForValue(tick)"
+          :y2="yForValue(tick)"
+          :class="tick === 0 ? 'activity-chart__baseline' : 'activity-chart__gridline'"
+        />
+        <text
+          v-for="(tick, i) in ticks"
+          :key="`ticklabel-${i}`"
+          :x="leftPad - 6"
+          :y="yForValue(tick) + 3"
+          class="activity-chart__ticklabel"
+          text-anchor="end"
+        >{{ compactNumber(tick) }}</text>
+      </g>
+
+      <!-- columns -->
+      <g v-for="(day, i) in daily" :key="day.date || i">
+        <template v-if="!isEmpty">
+          <path
+            v-if="segmentHeight(day, 'files') > 0"
+            :d="topRectPath(
+              slotX(i) + colOffset(i),
+              yForValue(day.texts || 0) - segmentHeight(day, 'files') - (segmentHeight(day, 'texts') > 0 ? gap : 0),
+              colWidth(i),
+              segmentHeight(day, 'files'),
+              4
+            )"
+            class="activity-chart__seg activity-chart__seg--file"
+            :class="{ 'activity-chart__seg--hover': hoveredIndex === i }"
+          />
+          <path
+            v-if="segmentHeight(day, 'texts') > 0"
+            :d="topRectPath(
+              slotX(i) + colOffset(i),
+              baselineY - segmentHeight(day, 'texts'),
+              colWidth(i),
+              segmentHeight(day, 'texts'),
+              segmentHeight(day, 'files') > 0 ? 0 : 4
+            )"
+            class="activity-chart__seg activity-chart__seg--text"
+            :class="{ 'activity-chart__seg--hover': hoveredIndex === i }"
+          />
+        </template>
+        <path
+          v-else
+          :d="topRectPath(slotX(i) + colOffset(i), baselineY - ghostHeight(i), colWidth(i), ghostHeight(i), 4)"
+          class="activity-chart__seg activity-chart__seg--ghost"
+        />
+
+        <!-- hit target: full slot band, full plot height -->
+        <rect
+          :x="slotX(i)"
+          :y="topPad"
+          :width="slotWidth"
+          :height="plotHeight"
+          class="activity-chart__hit"
+          tabindex="0"
+          :aria-label="dayTooltip(day)"
+          @mouseenter="hoveredIndex = i"
+          @mouseleave="hoveredIndex = null"
+          @focus="hoveredIndex = i"
+          @blur="hoveredIndex = null"
+        />
+      </g>
+    </svg>
+
+    <div
+      v-if="hoveredIndex !== null"
+      class="activity-chart__tooltip"
+      :style="tooltipStyle"
+    >
+      {{ dayTooltip(daily[hoveredIndex]) }}
+    </div>
+
+    <div v-if="isEmpty" class="activity-chart__caption">Activity will appear here</div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { compactNumber } from '../../utils/format.js';
+
+const props = defineProps({
+  daily: { type: Array, default: () => [] },
+});
+
+const wrapRef = ref(null);
+const hoveredIndex = ref(null);
+
+const viewBoxWidth = 600;
+const viewBoxHeight = 150;
+const leftPad = 30;
+const rightPad = 4;
+const topPad = 10;
+const bottomPad = 6;
+const gap = 2;
+
+const plotWidth = viewBoxWidth - leftPad - rightPad;
+const plotHeight = viewBoxHeight - topPad - bottomPad;
+const baselineY = topPad + plotHeight;
+
+const dayCount = computed(() => Math.max(props.daily.length, 1));
+const slotWidth = computed(() => plotWidth / dayCount.value);
+
+const totals = computed(() => {
+  let texts = 0;
+  let files = 0;
+  for (const day of props.daily) {
+    texts += Number(day?.texts) || 0;
+    files += Number(day?.files) || 0;
+  }
+  return { texts, files, all: texts + files };
+});
+
+const isEmpty = computed(() => totals.value.all === 0);
+
+const maxDailyTotal = computed(() => {
+  let max = 0;
+  for (const day of props.daily) {
+    const total = (Number(day?.texts) || 0) + (Number(day?.files) || 0);
+    if (total > max) max = total;
+  }
+  return max;
+});
+
+/** "Nice" rounded step for an axis, biased toward whole-number counts. */
+function niceStep(rawStep) {
+  if (rawStep <= 0) return 1;
+  const exponent = Math.floor(Math.log10(rawStep));
+  const fraction = rawStep / Math.pow(10, exponent);
+  let niceFraction;
+  if (fraction < 1.5) niceFraction = 1;
+  else if (fraction < 3) niceFraction = 2;
+  else if (fraction < 7) niceFraction = 5;
+  else niceFraction = 10;
+  return Math.max(1, Math.round(niceFraction * Math.pow(10, exponent)));
+}
+
+const ticks = computed(() => {
+  const tickCount = 4; // baseline (0) + 3 gridlines
+  if (maxDailyTotal.value <= 0) {
+    return [0, 1, 2, 3];
+  }
+  const step = niceStep(maxDailyTotal.value / (tickCount - 1));
+  return Array.from({ length: tickCount }, (_, i) => step * i);
+});
+
+const scaleMax = computed(() => ticks.value[ticks.value.length - 1] || 1);
+
+function yForValue(value) {
+  const ratio = scaleMax.value > 0 ? value / scaleMax.value : 0;
+  return baselineY - ratio * plotHeight;
+}
+
+function segmentHeight(day, key) {
+  const value = Number(day?.[key]) || 0;
+  return baselineY - yForValue(value);
+}
+
+function slotX(i) {
+  return leftPad + i * slotWidth.value;
+}
+
+function colWidth(i) {
+  return Math.min(24, slotWidth.value - gap);
+}
+
+function colOffset(i) {
+  return (slotWidth.value - colWidth(i)) / 2;
+}
+
+function ghostHeight(i) {
+  // Deterministic gentle variation so the empty state doesn't look like a flat wall.
+  return plotHeight * (0.12 + 0.35 * Math.abs(Math.sin(i * 1.7 + 1)));
+}
+
+/** Rect path with rounded top corners and a square baseline. */
+function topRectPath(x, y, width, height, radius) {
+  const r = Math.max(0, Math.min(radius, height / 2, width / 2));
+  if (r === 0) {
+    return `M${x},${y} H${x + width} V${y + height} H${x} Z`;
+  }
+  return [
+    `M${x},${y + r}`,
+    `A${r},${r} 0 0 1 ${x + r},${y}`,
+    `H${x + width - r}`,
+    `A${r},${r} 0 0 1 ${x + width},${y + r}`,
+    `V${y + height}`,
+    `H${x}`,
+    `Z`,
+  ].join(' ');
+}
+
+function formatDayLabel(dateStr) {
+  if (!dateStr) return '';
+  const [y, m, d] = String(dateStr).split('-').map(Number);
+  if (!y || !m || !d) return dateStr;
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+function dayTooltip(day) {
+  if (!day) return '';
+  const texts = Number(day.texts) || 0;
+  const files = Number(day.files) || 0;
+  return `${formatDayLabel(day.date)} – ${texts} text${texts === 1 ? '' : 's'}, ${files} file${files === 1 ? '' : 's'}`;
+}
+
+const ariaLabel = computed(() => {
+  const { texts, files, all } = totals.value;
+  return `${all} secrets over the last ${props.daily.length} days, ${texts} text and ${files} files`;
+});
+
+const tooltipStyle = computed(() => {
+  if (hoveredIndex.value === null) return {};
+  const centerX = slotX(hoveredIndex.value) + slotWidth.value / 2;
+  const leftPercent = (centerX / viewBoxWidth) * 100;
+  return {
+    left: `${leftPercent}%`,
+    top: `${(topPad / viewBoxHeight) * 100}%`,
+  };
+});
+</script>
+
+<style scoped>
+.activity-chart {
+  position: relative;
+  width: 100%;
+}
+
+.activity-chart__svg {
+  width: 100%;
+  height: 150px;
+  display: block;
+  overflow: visible;
+}
+
+.activity-chart__gridline {
+  stroke: rgba(var(--v-theme-on-surface), 0.08);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.activity-chart__baseline {
+  stroke: rgba(var(--v-theme-on-surface), 0.2);
+  stroke-width: 1;
+  vector-effect: non-scaling-stroke;
+}
+
+.activity-chart__ticklabel {
+  font-size: 9px;
+  fill: rgba(var(--v-theme-on-surface), 0.5);
+}
+
+.activity-chart__seg--text {
+  fill: rgb(var(--v-theme-chart-text));
+}
+
+.activity-chart__seg--file {
+  fill: rgb(var(--v-theme-chart-file));
+}
+
+.activity-chart__seg--ghost {
+  fill: rgba(var(--v-theme-on-surface), 0.08);
+}
+
+.activity-chart__seg {
+  transition: opacity 0.15s ease;
+}
+
+.activity-chart__seg--hover {
+  opacity: 0.85;
+}
+
+.activity-chart__hit {
+  fill: transparent;
+  cursor: pointer;
+  outline: none;
+}
+
+.activity-chart__hit:focus-visible {
+  fill: rgba(var(--v-theme-on-surface), 0.04);
+}
+
+.activity-chart__tooltip {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  background: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-on-surface));
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1;
+}
+
+.activity-chart__caption {
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  margin-top: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-chart__seg {
+    transition: none;
+  }
+}
+</style>

--- a/ui/src/components/stats/MilestoneMeter.vue
+++ b/ui/src/components/stats/MilestoneMeter.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="milestone-meter">
+    <svg
+      class="milestone-meter__svg"
+      viewBox="0 0 200 8"
+      preserveAspectRatio="none"
+      role="img"
+      :aria-label="ariaLabel"
+    >
+      <path :d="trackPath" class="milestone-meter__track" />
+      <path v-if="progress > 0" :d="fillPath" class="milestone-meter__fill" />
+    </svg>
+
+    <div class="milestone-meter__caption">{{ caption }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { compactNumber } from '../../utils/format.js';
+
+const props = defineProps({
+  total: { type: Number, default: 0 },
+});
+
+const LADDER = [10, 100, 500, 1000, 5000, 10000, 50000, 100000];
+
+const barWidth = 200;
+const barHeight = 8;
+const radius = barHeight / 2;
+
+const rungs = computed(() => {
+  const total = Number(props.total) || 0;
+  let prev = 0;
+  for (const rung of LADDER) {
+    if (total < rung) return { prev, next: rung, maxed: false };
+    prev = rung;
+  }
+  return { prev, next: null, maxed: true };
+});
+
+const isFresh = computed(() => (Number(props.total) || 0) === 0);
+
+const progress = computed(() => {
+  const { prev, next, maxed } = rungs.value;
+  if (maxed) return 1;
+  const span = next - prev;
+  if (span <= 0) return 0;
+  const total = Number(props.total) || 0;
+  return Math.min(1, Math.max(0, (total - prev) / span));
+});
+
+const caption = computed(() => {
+  const total = Number(props.total) || 0;
+  const { next, maxed } = rungs.value;
+  if (isFresh.value) return 'First milestone: 10 secrets';
+  if (maxed) return `Max milestone reached — ${compactNumber(total)} secrets`;
+  const remaining = Math.max(0, next - total);
+  return `${compactNumber(remaining)} to ${compactNumber(next)}`;
+});
+
+const ariaLabel = computed(() => `Milestone progress: ${caption.value}`);
+
+/** Full rounded pill covering [x, x+width]. */
+function pillPath(x, width) {
+  const r = Math.min(radius, width / 2, barHeight / 2);
+  if (r <= 0) return '';
+  return `M${x + r},0 H${x + width - r} A${r},${r} 0 0 1 ${x + width},${r} V${barHeight - r} A${r},${r} 0 0 1 ${x + width - r},${barHeight} H${x + r} A${r},${r} 0 0 1 ${x},${barHeight - r} V${r} A${r},${r} 0 0 1 ${x + r},0 Z`;
+}
+
+/** Rounded-left / square-right rect, for a partial fill. */
+function leftRoundedPath(width) {
+  const r = Math.min(radius, width / 2, barHeight / 2);
+  if (r <= 0) return '';
+  return `M${r},0 H${width} V${barHeight} H${r} A${r},${r} 0 0 1 0,${barHeight - r} V${r} A${r},${r} 0 0 1 ${r},0 Z`;
+}
+
+const trackPath = computed(() => pillPath(0, barWidth));
+const fillPath = computed(() => {
+  const width = barWidth * progress.value;
+  return progress.value >= 1 ? pillPath(0, barWidth) : leftRoundedPath(width);
+});
+</script>
+
+<style scoped>
+.milestone-meter {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+
+.milestone-meter__svg {
+  width: 100%;
+  height: 8px;
+  display: block;
+}
+
+.milestone-meter__track {
+  fill: rgba(var(--v-theme-primary), 0.16);
+}
+
+.milestone-meter__fill {
+  fill: rgb(var(--v-theme-primary));
+}
+
+.milestone-meter__caption {
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+</style>

--- a/ui/src/components/stats/ServerLedger.vue
+++ b/ui/src/components/stats/ServerLedger.vue
@@ -1,0 +1,234 @@
+<template>
+  <div v-if="loading" class="server-ledger server-ledger--loading" aria-busy="true" aria-live="polite">
+    <div class="server-ledger__skeleton-eyebrow" />
+    <div class="server-ledger__skeleton-hero" />
+    <div class="server-ledger__skeleton-row">
+      <div class="server-ledger__skeleton-tile" v-for="n in 4" :key="n" />
+    </div>
+    <div class="server-ledger__skeleton-chart" />
+  </div>
+
+  <div v-else-if="stats" class="server-ledger gd-fade-in">
+    <div class="server-ledger__eyebrow font-display">THIS SERVER</div>
+
+    <StatTile
+      class="server-ledger__hero"
+      :class="{ 'server-ledger__hero--glow': glowing }"
+      label="Secrets delivered"
+      :value="local.total"
+      :caption="heroCaption"
+      hero
+    />
+
+    <v-divider class="server-ledger__divider" />
+
+    <div class="server-ledger__grid">
+      <StatTile label="Text secrets" :value="local.texts" swatch="text" />
+      <StatTile label="Files shared" :value="local.files" swatch="file" />
+      <StatTile label="Data encrypted" :value="local.bytes" format="bytes" />
+      <StatTile label="Held right now" :value="local.active" caption="awaiting pickup" />
+    </div>
+
+    <SplitBar :texts="local.texts" :files="local.files" class="server-ledger__section" />
+
+    <ActivityChart :daily="local.daily" class="server-ledger__section" />
+
+    <MilestoneMeter :total="local.total" class="server-ledger__section" />
+  </div>
+
+  <!-- error/null: render nothing so the form column can center itself -->
+</template>
+
+<script setup>
+import { ref, reactive, computed, onMounted } from 'vue';
+import { getStats } from '../../services/api.js';
+import StatTile from './StatTile.vue';
+import ActivityChart from './ActivityChart.vue';
+import SplitBar from './SplitBar.vue';
+import MilestoneMeter from './MilestoneMeter.vue';
+
+const loading = ref(true);
+const stats = ref(null);
+const glowing = ref(false);
+
+// Local reactive copy of the lifetime figures + daily buckets, seeded from
+// the fetched stats. tick() mutates these so StatTiles (which read only
+// from `local`) animate a live +1 without waiting on the server.
+const local = reactive({
+  total: 0,
+  texts: 0,
+  files: 0,
+  bytes: 0,
+  active: 0,
+  daily: [],
+});
+
+function prefersReducedMotion() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+onMounted(async () => {
+  const result = await getStats();
+
+  if (result) {
+    stats.value = result;
+    local.total = result.lifetime?.total ?? 0;
+    local.texts = result.lifetime?.texts ?? 0;
+    local.files = result.lifetime?.files ?? 0;
+    local.bytes = result.lifetime?.bytes ?? 0;
+    local.active = result.active?.total ?? 0;
+    local.daily = (result.daily ?? []).map((day) => ({ ...day }));
+  }
+
+  loading.value = false;
+});
+
+const isEmpty = computed(() => local.total === 0);
+
+const sinceLabel = computed(() => {
+  if (!stats.value?.since) return '';
+  const date = new Date(stats.value.since);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+});
+
+const heroCaption = computed(() =>
+  isEmpty.value ? 'Be the first to drop a secret' : `since ${sinceLabel.value}`
+);
+
+let glowTimeout = null;
+
+/**
+ * Optimistically bumps the local ledger after a successful create, so the
+ * hero figure visibly counts up without waiting on a re-fetch.
+ * @param {"text"|"file"} type
+ */
+function tick(type) {
+  if (!stats.value) return;
+
+  local.total += 1;
+
+  const key = type === 'file' ? 'files' : 'texts';
+  local[key] += 1;
+
+  const today = local.daily[local.daily.length - 1];
+  if (today) {
+    today[key] = (today[key] || 0) + 1;
+  }
+
+  if (!prefersReducedMotion()) {
+    glowing.value = true;
+    clearTimeout(glowTimeout);
+    glowTimeout = setTimeout(() => {
+      glowing.value = false;
+    }, 400);
+  }
+}
+
+defineExpose({ tick });
+</script>
+
+<style scoped>
+.server-ledger {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 8px 0;
+}
+
+.server-ledger__eyebrow {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-on-surface), 0.55);
+}
+
+.server-ledger__divider {
+  opacity: 0.6;
+}
+
+.server-ledger__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.server-ledger__section {
+  margin-top: 4px;
+}
+
+.server-ledger__hero :deep(.stat-tile__value) {
+  transition: text-shadow 0.4s ease, color 0.4s ease;
+}
+
+.server-ledger__hero--glow :deep(.stat-tile__value) {
+  color: rgb(var(--v-theme-primary));
+  text-shadow: 0 0 18px rgba(var(--v-theme-primary), 0.55);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .server-ledger__hero :deep(.stat-tile__value) {
+    transition: none;
+  }
+}
+
+/* Loading skeleton */
+.server-ledger--loading {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 8px 0;
+}
+
+.server-ledger__skeleton-eyebrow,
+.server-ledger__skeleton-hero,
+.server-ledger__skeleton-tile,
+.server-ledger__skeleton-chart {
+  background: rgba(var(--v-theme-on-surface), 0.08);
+  border-radius: 8px;
+  animation: server-ledger-pulse 1.4s ease-in-out infinite;
+}
+
+.server-ledger__skeleton-eyebrow {
+  width: 30%;
+  height: 12px;
+}
+
+.server-ledger__skeleton-hero {
+  width: 60%;
+  height: 48px;
+}
+
+.server-ledger__skeleton-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px 24px;
+}
+
+.server-ledger__skeleton-tile {
+  height: 40px;
+}
+
+.server-ledger__skeleton-chart {
+  height: 150px;
+}
+
+@keyframes server-ledger-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .server-ledger__skeleton-eyebrow,
+  .server-ledger__skeleton-hero,
+  .server-ledger__skeleton-tile,
+  .server-ledger__skeleton-chart {
+    animation: none;
+  }
+}
+</style>

--- a/ui/src/components/stats/SplitBar.vue
+++ b/ui/src/components/stats/SplitBar.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="split-bar">
+    <div class="split-bar__labels">
+      <span class="split-bar__label">Text {{ textPercent }}%</span>
+      <span class="split-bar__label">Files {{ filePercent }}%</span>
+    </div>
+
+    <svg
+      class="split-bar__svg"
+      viewBox="0 0 200 12"
+      preserveAspectRatio="none"
+      role="img"
+      :aria-label="`Text ${textPercent}%, Files ${filePercent}%`"
+    >
+      <rect
+        v-if="total === 0"
+        x="0"
+        y="0"
+        width="200"
+        height="12"
+        rx="6"
+        class="split-bar__track"
+      />
+      <template v-else>
+        <path
+          v-if="textWidth > 0"
+          :d="textPath"
+          class="split-bar__seg split-bar__seg--text"
+        />
+        <path
+          v-if="fileWidth > 0"
+          :d="filePath"
+          class="split-bar__seg split-bar__seg--file"
+        />
+      </template>
+    </svg>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  texts: { type: Number, default: 0 },
+  files: { type: Number, default: 0 },
+});
+
+const barWidth = 200;
+const barHeight = 12;
+const radius = barHeight / 2;
+const gap = 2;
+
+const total = computed(() => (Number(props.texts) || 0) + (Number(props.files) || 0));
+
+const textPercent = computed(() =>
+  total.value > 0 ? Math.round(((Number(props.texts) || 0) / total.value) * 100) : 0
+);
+const filePercent = computed(() =>
+  total.value > 0 ? Math.round(((Number(props.files) || 0) / total.value) * 100) : 0
+);
+
+const usableWidth = barWidth - gap;
+
+const textWidth = computed(() =>
+  total.value > 0 ? usableWidth * ((Number(props.texts) || 0) / total.value) : 0
+);
+const fileWidth = computed(() =>
+  total.value > 0 ? usableWidth * ((Number(props.files) || 0) / total.value) : 0
+);
+
+/** Rounded-left / square-right rect path. */
+function leftRoundedPath(width, roundRight) {
+  const r = Math.max(0, Math.min(radius, width / 2, barHeight / 2));
+  if (roundRight) {
+    // The only segment present - round both ends (a full pill).
+    return `M${r},0 H${width - r} A${r},${r} 0 0 1 ${width},${r} V${barHeight - r} A${r},${r} 0 0 1 ${width - r},${barHeight} H${r} A${r},${r} 0 0 1 0,${barHeight - r} V${r} A${r},${r} 0 0 1 ${r},0 Z`;
+  }
+  return `M${r},0 H${width} V${barHeight} H${r} A${r},${r} 0 0 1 0,${barHeight - r} V${r} A${r},${r} 0 0 1 ${r},0 Z`;
+}
+
+/** Square-left / rounded-right rect path, offset to start at x. */
+function rightRoundedPath(x, width, roundLeft) {
+  const r = Math.max(0, Math.min(radius, width / 2, barHeight / 2));
+  if (roundLeft) {
+    // The only segment present - round both ends (a full pill).
+    return `M${x + r},0 H${x + width - r} A${r},${r} 0 0 1 ${x + width},${r} V${barHeight - r} A${r},${r} 0 0 1 ${x + width - r},${barHeight} H${x + r} A${r},${r} 0 0 1 ${x},${barHeight - r} V${r} A${r},${r} 0 0 1 ${x + r},0 Z`;
+  }
+  return `M${x},0 H${x + width - r} A${r},${r} 0 0 1 ${x + width},${r} V${barHeight - r} A${r},${r} 0 0 1 ${x + width - r},${barHeight} H${x} Z`;
+}
+
+const textPath = computed(() => leftRoundedPath(textWidth.value, fileWidth.value === 0));
+const filePath = computed(() =>
+  rightRoundedPath(textWidth.value > 0 ? textWidth.value + gap : 0, fileWidth.value, textWidth.value === 0)
+);
+</script>
+
+<style scoped>
+.split-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+
+.split-bar__labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.87);
+}
+
+.split-bar__svg {
+  width: 100%;
+  height: 12px;
+  display: block;
+}
+
+.split-bar__track {
+  fill: rgba(var(--v-theme-on-surface), 0.08);
+}
+
+.split-bar__seg--text {
+  fill: rgb(var(--v-theme-chart-text));
+}
+
+.split-bar__seg--file {
+  fill: rgb(var(--v-theme-chart-file));
+}
+</style>

--- a/ui/src/components/stats/StatTile.vue
+++ b/ui/src/components/stats/StatTile.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="stat-tile" :class="{ 'stat-tile--hero': hero }">
+    <div class="stat-tile__eyebrow">
+      <span
+        v-if="swatch"
+        class="stat-tile__swatch"
+        :class="`stat-tile__swatch--${swatch}`"
+        aria-hidden="true"
+      />
+      <span class="stat-tile__label">{{ label }}</span>
+    </div>
+
+    <div
+      class="stat-tile__value"
+      :class="{ 'font-display': hero }"
+    >
+      {{ displayValue }}
+    </div>
+
+    <div v-if="caption" class="stat-tile__caption">{{ caption }}</div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useCountUp } from '../../composables/useCountUp.js';
+import { compactNumber, formatBytes } from '../../utils/format.js';
+
+const props = defineProps({
+  label: { type: String, required: true },
+  value: { type: Number, required: true },
+  caption: { type: String, default: null },
+  hero: { type: Boolean, default: false },
+  swatch: { type: String, default: null }, // "text" | "file" | null
+  format: { type: String, default: 'number' }, // "number" | "bytes"
+});
+
+const target = computed(() => props.value);
+const animated = useCountUp(target, { durationMs: 700 });
+
+const displayValue = computed(() => {
+  const rounded = Math.round(animated.value);
+  return props.format === 'bytes' ? formatBytes(rounded) : compactNumber(rounded);
+});
+</script>
+
+<style scoped>
+.stat-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.stat-tile__eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stat-tile__swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.stat-tile__swatch--text {
+  background-color: rgb(var(--v-theme-chart-text));
+}
+
+.stat-tile__swatch--file {
+  background-color: rgb(var(--v-theme-chart-file));
+}
+
+.stat-tile__label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.stat-tile__value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: rgb(var(--v-theme-on-surface));
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-tile--hero .stat-tile__value {
+  font-size: 3rem;
+  line-height: 1.1;
+}
+
+.stat-tile__value.font-display {
+  font-family: 'Space Grotesk Variable', 'Space Grotesk', sans-serif;
+}
+
+.stat-tile__caption {
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+</style>

--- a/ui/src/composables/useCountUp.js
+++ b/ui/src/composables/useCountUp.js
@@ -1,0 +1,88 @@
+import { ref, watch, onUnmounted, unref } from 'vue';
+
+/**
+ * Ease-out cubic - fast start, gentle settle.
+ * @param {number} t progress in [0, 1]
+ */
+function easeOutCubic(t) {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function prefersReducedMotion() {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/**
+ * Animate a displayed number toward a source value whenever it changes.
+ * Powers the "+1 tick" feel after creating a secret, and re-animates on
+ * every subsequent change to the source.
+ *
+ * @param {import('vue').Ref<number>|(() => number)} source - ref or getter holding the target number
+ * @param {{ durationMs?: number }} [options]
+ * @returns {import('vue').Ref<number>} display - the animated, currently-rendered value
+ */
+export function useCountUp(source, options = {}) {
+  const durationMs = options.durationMs ?? 700;
+
+  const getTarget = () => {
+    const value = typeof source === 'function' ? source() : unref(source);
+    return Number(value) || 0;
+  };
+
+  const display = ref(getTarget());
+
+  let rafId = null;
+
+  function cancel() {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  }
+
+  function animateTo(target) {
+    cancel();
+
+    if (prefersReducedMotion()) {
+      display.value = target;
+      return;
+    }
+
+    const start = display.value;
+    const delta = target - start;
+    if (delta === 0) return;
+
+    const startTime = performance.now();
+
+    const tick = (now) => {
+      const elapsed = now - startTime;
+      const progress = Math.min(elapsed / durationMs, 1);
+      const eased = easeOutCubic(progress);
+      display.value = start + delta * eased;
+
+      if (progress < 1) {
+        rafId = requestAnimationFrame(tick);
+      } else {
+        display.value = target;
+        rafId = null;
+      }
+    };
+
+    rafId = requestAnimationFrame(tick);
+  }
+
+  watch(
+    typeof source === 'function' ? source : () => unref(source),
+    (newValue) => {
+      animateTo(Number(newValue) || 0);
+    }
+  );
+
+  onUnmounted(cancel);
+
+  return display;
+}

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -2,6 +2,10 @@
  * Main application entry point.
  * Initializes Vue, Vuetify, and the Router.
  */
+import "@fontsource-variable/inter";
+import "@fontsource-variable/space-grotesk";
+import "./assets/style.css";
+
 import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
@@ -23,6 +27,8 @@ const customLightTheme = {
     error: '#B3261E',
     success: '#4CAF50',
     warning: '#FB8C00',
+    'chart-text': '#6750A4',
+    'chart-file': '#00897B',
   }
 };
 
@@ -38,6 +44,8 @@ const customDarkTheme = {
     error: '#F2B8B5',
     success: '#B7F3B9',
     warning: '#FFD6A8',
+    'chart-text': '#9A79DC',
+    'chart-file': '#22A896',
   }
 }
 

--- a/ui/src/pages/Create.vue
+++ b/ui/src/pages/Create.vue
@@ -1,93 +1,93 @@
 <template>
-  <v-container class="d-flex justify-center align-center fill-height">
-    <v-card class="pa-4 pa-md-8 animate__animated animate__fadeIn" max-width="600" elevation="6" rounded="lg">
-      <v-card-title class="text-h5 text-md-h4 font-weight-bold text-center mb-4">Create a New Secret 🔑</v-card-title>
-      <v-card-text>
-        <v-form @submit.prevent="handleSubmit">
-          <v-btn-toggle
-            v-model="type"
-            mandatory
-            class="mb-4 d-flex justify-center"
-            color="primary"
-            rounded
-            group
-          >
-            <v-btn value="text" class="px-6" rounded>
-              <v-icon left>mdi-text</v-icon> Text
-            </v-btn>
-            <v-btn value="file" class="px-6" rounded>
-              <v-icon left>mdi-file</v-icon> File
-            </v-btn>
-          </v-btn-toggle>
+  <v-container class="create-page">
+    <div class="create-page__headline">
+      <h1 class="font-display text-h4 text-md-h3 font-weight-bold">Share secrets that vanish.</h1>
+      <p class="create-page__subhead">Encrypted on this server. Delivered once. Then destroyed.</p>
+    </div>
 
-          <v-textarea
-            v-if="type === 'text'"
-            label="Text Secret"
-            v-model="textSecret"
-            required
-            variant="outlined"
-            rows="4"
-          ></v-textarea>
-
-          <v-file-input
-            v-if="type === 'file'"
-            label="Select File"
-            prepend-icon="mdi-upload"
-            v-model="files"
-            show-size
-            required
-            variant="outlined"
-          ></v-file-input>
-
-          <PasswordInput v-model="password" class="mt-2" />
-
-          <v-select
-            label="Expiration"
-            v-model="expires"
-            :items="expirationOptions"
-            required
-            variant="outlined"
-            class="mt-2"
-          ></v-select>
-
-          <v-checkbox
-            v-model="oneTime"
-            label="One-Time Retrieval"
-            color="primary"
-            class="mt-2"
-          ></v-checkbox>
-
-          <v-btn type="submit" color="primary" class="mt-4" block large rounded x-large height="50">Create Secret</v-btn>
-
-          <v-alert v-if="errorMessage" type="error" class="mt-4 animate__animated animate__bounceIn" variant="tonal">
-            {{ errorMessage }}
-          </v-alert>
-        </v-form>
-
-        <v-alert v-if="resultHash" type="success" class="mt-6 animate__animated animate__fadeIn" variant="tonal">
-          <div class="text-h6 mb-2">Secret Created!</div>
-          <p>Share this link to view the secret:</p>
-          <div class="d-flex align-center mt-2 pa-2" style="background-color: rgba(var(--v-theme-on-surface), 0.05); border-radius: 8px;">
-            <span class="mr-2 text-truncate">{{ baseUrl }}/view/{{ resultHash }}</span>
-            <v-spacer></v-spacer>
-            <v-tooltip text="Copy Link to Clipboard">
-              <template v-slot:activator="{ props }">
-                <v-btn icon v-bind="props" @click="copyLink">
-                  <v-icon>mdi-content-copy</v-icon>
+    <v-row class="create-page__row">
+      <v-col cols="12" md="7" order="1">
+        <v-card class="pa-4 pa-md-8 animate__animated animate__fadeIn" elevation="6" rounded="lg">
+          <v-card-title class="text-h5 text-md-h4 font-weight-bold text-center mb-4">Create a New Secret 🔑</v-card-title>
+          <v-card-text>
+            <v-form @submit.prevent="handleSubmit">
+              <v-btn-toggle
+                v-model="type"
+                mandatory
+                class="mb-4 d-flex justify-center"
+                color="primary"
+                rounded
+                group
+              >
+                <v-btn value="text" class="px-6" rounded>
+                  <v-icon left>mdi-text</v-icon> Text
                 </v-btn>
-              </template>
-            </v-tooltip>
-          </div>
-          <v-snackbar v-model="snackbar" timeout="2000" color="success">
-            Link copied to clipboard!
-          </v-snackbar>
-        </v-alert>
+                <v-btn value="file" class="px-6" rounded>
+                  <v-icon left>mdi-file</v-icon> File
+                </v-btn>
+              </v-btn-toggle>
 
-        <v-overlay v-model="loading" class="align-center justify-center">
-          <v-progress-circular indeterminate color="primary" size="64"></v-progress-circular>
-        </v-overlay>
-      </v-card-text>
-    </v-card>
+              <v-textarea
+                v-if="type === 'text'"
+                label="Text Secret"
+                v-model="textSecret"
+                required
+                variant="outlined"
+                rows="4"
+              ></v-textarea>
+
+              <v-file-input
+                v-if="type === 'file'"
+                label="Select File"
+                prepend-icon="mdi-upload"
+                v-model="files"
+                show-size
+                required
+                variant="outlined"
+              ></v-file-input>
+
+              <PasswordInput v-model="password" class="mt-2" />
+
+              <v-select
+                label="Expiration"
+                v-model="expires"
+                :items="expirationOptions"
+                required
+                variant="outlined"
+                class="mt-2"
+              ></v-select>
+
+              <v-checkbox
+                v-model="oneTime"
+                label="One-Time Retrieval"
+                color="primary"
+                class="mt-2"
+              ></v-checkbox>
+
+              <v-btn type="submit" color="primary" class="mt-4" block large rounded x-large height="50">Create Secret</v-btn>
+
+              <v-alert v-if="errorMessage" type="error" class="mt-4 animate__animated animate__bounceIn" variant="tonal">
+                {{ errorMessage }}
+              </v-alert>
+            </v-form>
+
+            <SecretResult
+              v-if="resultHash"
+              :link="`${baseUrl}/view/${resultHash}`"
+              @create-another="resetForm"
+            />
+
+            <v-overlay v-model="loading" class="align-center justify-center">
+              <v-progress-circular indeterminate color="primary" size="64"></v-progress-circular>
+            </v-overlay>
+          </v-card-text>
+        </v-card>
+      </v-col>
+
+      <v-col cols="12" md="5" order="2">
+        <ServerLedger ref="ledger" />
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
@@ -95,6 +95,8 @@
 import { ref, watch } from 'vue';
 import { createSend } from '../services/api.js';
 import PasswordInput from '../components/PasswordInput.vue';
+import SecretResult from '../components/SecretResult.vue';
+import ServerLedger from '../components/stats/ServerLedger.vue';
 import { formStore } from '../stores/formStore.js';
 
 const type = ref('text');
@@ -107,8 +109,8 @@ const expires = ref('24h');
 const errorMessage = ref('');
 const resultHash = ref('');
 const baseUrl = window.location.origin;
-const snackbar = ref(false);
 const loading = ref(false);
+const ledger = ref(null);
 
 const expirationOptions = [
   { title: '1 Hour', value: '1h' },
@@ -151,8 +153,6 @@ async function handleSubmit() {
     }
     formData.append('data', textSecret.value);
   } else if (type.value === 'file') {
-    // Debug log
-    console.log('files.value:', files.value);
     // Ensure files.value is an array and has a File object
     const fileArr = Array.isArray(files.value) ? files.value : (files.value ? [files.value] : []);
     if (!fileArr.length || !(fileArr[0] instanceof File)) {
@@ -174,7 +174,9 @@ async function handleSubmit() {
 
   try {
     const result = await createSend(formData);
+    const createdType = type.value;
     resultHash.value = result.hash;
+    ledger.value?.tick(createdType);
     // Clear form inputs but keep the result hash visible
     type.value = 'text';
     textSecret.value = '';
@@ -188,17 +190,25 @@ async function handleSubmit() {
     loading.value = false;
   }
 }
-
-function copyLink() {
-  const link = `${baseUrl}/view/${resultHash.value}`;
-  navigator.clipboard.writeText(link);
-  snackbar.value = true;
-}
 </script>
 
 <style scoped>
-.v-container {
+.create-page {
   min-height: 85vh;
+}
+
+.create-page__headline {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.create-page__subhead {
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  margin-top: 4px;
+}
+
+.create-page__row {
+  align-items: flex-start;
 }
 
 .v-card {

--- a/ui/src/services/api.js
+++ b/ui/src/services/api.js
@@ -101,3 +101,24 @@ export async function checkPasswordProtection(hash) {
 
   return res.json();
 }
+
+/**
+ * Fetches server-wide aggregate stats for the "server ledger" UI.
+ * Degrades silently: any non-ok status, a 404, or a network error
+ * resolves to null so the UI never depends on stats being available.
+ * @returns {Promise<object|null>} The parsed stats JSON, or null.
+ */
+export async function getStats() {
+  try {
+    const res = await fetch(`${API_URL}/stats`);
+
+    if (!res.ok) {
+      return null;
+    }
+
+    return await res.json();
+  } catch (err) {
+    console.error('Failed to fetch stats:', err);
+    return null;
+  }
+}

--- a/ui/src/utils/format.js
+++ b/ui/src/utils/format.js
@@ -1,0 +1,65 @@
+/**
+ * Pure formatting helpers for the stats dashboard.
+ * No DOM/Vue dependencies - safe to unit test in isolation.
+ */
+
+/**
+ * Format an integer as a locale-grouped string, e.g. 1284 -> "1,284".
+ * Values at or above 100,000 compact to a single decimal + suffix,
+ * e.g. 128400 -> "128.4K", 12900000 -> "12.9M", 1284000000 -> "1.3B".
+ *
+ * @param {number} n
+ * @returns {string}
+ */
+const COMPACT_UNITS = ['', 'K', 'M', 'B'];
+
+export function compactNumber(n) {
+  const value = Number(n) || 0;
+  const abs = Math.abs(value);
+
+  if (abs < 100_000) {
+    return Math.round(value).toLocaleString('en-US');
+  }
+
+  let exponent = Math.min(Math.floor(Math.log10(abs) / 3), COMPACT_UNITS.length - 1);
+  let scaled = trimDecimal(value / Math.pow(1000, exponent));
+
+  // A value like 999,999 rounds to "1000K" at one decimal - bump to the next unit.
+  if (Math.abs(parseFloat(scaled)) >= 1000 && exponent < COMPACT_UNITS.length - 1) {
+    exponent += 1;
+    scaled = trimDecimal(value / Math.pow(1000, exponent));
+  }
+
+  return `${scaled}${COMPACT_UNITS[exponent]}`;
+}
+
+/**
+ * Format a byte count into human-readable units (base 1024).
+ * e.g. 0 -> "0 B", 5153960755 -> "4.8 GB"
+ *
+ * @param {number} n
+ * @returns {string}
+ */
+export function formatBytes(n) {
+  const value = Number(n) || 0;
+  if (value <= 0) return '0 B';
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  const exponent = Math.min(
+    Math.floor(Math.log(value) / Math.log(1024)),
+    units.length - 1
+  );
+  const scaled = value / Math.pow(1024, exponent);
+  const decimals = exponent === 0 ? 0 : 1;
+
+  return `${scaled.toFixed(decimals)} ${units[exponent]}`;
+}
+
+/**
+ * Round to one decimal place, dropping a trailing ".0",
+ * e.g. 12.94 -> "12.9", 250.0 -> "250".
+ */
+function trimDecimal(n) {
+  const rounded = Math.round(n * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}

--- a/version.yaml
+++ b/version.yaml
@@ -1,2 +1,2 @@
 #Application version following https://semver.org/
-version: 1.0.10
+version: 1.1.0


### PR DESCRIPTION
## Overview

Revamps the GopherDrop landing page into a modern, two-column layout and adds a **gamified "server ledger"** — a live stats dashboard that turns the app's ephemeral nature into its personality: *"this server has delivered N secrets."*

The signature moment: the hero **"Secrets delivered" figure ticks +1 with a count-up animation** the instant you create a secret — your action visibly joins the tally.

Planned by a `fable` design agent, implemented by a parallel `sonnet` swarm (disjoint file ownership), verified (build + tests green), and reviewed by an `opus` adversary before merge.

## Frontend

- **New landing page**: "Share secrets that vanish." hero, create form (left) + server ledger (right), collapsing to form-first on mobile.
- **Server ledger** (`ServerLedger.vue`): lifetime KPI tiles (Secrets Delivered / Text Secrets / Files Shared / Data Encrypted) + a live **"Held right now"** count, a 30-day **stacked activity chart** (text vs. file), a **split bar**, and a **milestone meter**.
- **Zero new charting deps** — every chart is hand-rolled inline SVG that themes off Vuetify CSS vars (text = purple, file = teal, in light & dark).
- `useCountUp` composable + count-up/tick animations, all `prefers-reduced-motion`-aware. Empty/fresh-install states are designed, not broken.
- Extracted the post-create success panel into `SecretResult.vue`.

## Backend

- New public, **aggregate-only** `GET /stats` endpoint (no per-secret data ever exposed), with a **30s in-memory cache** so it needs no rate limiter. Toggle via `STATS_ENABLED` (default `true`).
- **Monotonic counters** (`stat_counters`) + per-day activity (`stat_days`). They are incremented at creation and **never decremented** by expiry or one-time retrieval — so lifetime totals stay honest even though secrets are ephemeral. A `since` timestamp keeps the "lifetime" number honest on pre-existing installs.
- Counter writes are **best-effort, atomic upserts** (self-healing if the seed row is missing) and never affect the create response body.
- Create path now **verifies the DB insert succeeded** before returning a link (previously the insert error was ignored).

## Privacy

- **Removed all third-party CDN requests on page load.** Inter + Space Grotesk are now self-hosted via `@fontsource`; the `animate.css` CDN link was dropped (its animations re-implemented locally). A privacy tool should not phone home.

## Adversary review outcome

The opus adversary raised 8 findings. Fixed: self-healing counters, unchecked `db.Create`, unbounded `stat_days` scan, leftover `console.log`, tooltip pluralization. **Intentionally kept synchronous** (documented in code): inline stats writes — the create endpoint is rate-limited to ~1 req/s, so hot-row contention is a non-issue, and a goroutine would flake the in-memory sqlite test DB.

## Verification

- `go build ./...` ✅ · `go test ./...` ✅ (new tests: counters increment on create, **do not** decrement on delete/expiry, `/stats` shape + 30 zero-filled days + `STATS_ENABLED=false` returns 404)
- `npm run build` ✅ (self-hosted font woff2 bundled; no CDN)

Bumps version `1.0.10 → 1.1.0`.