### PR TITLE
feat(ui): headerless landing page with seamless create form + dark-mode fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.2.0]
+
+### Changed
+- **Headerless, "straight to the point" landing page.** Removed the top app-bar entirely; brand wordmark and theme toggle now live in a quiet, borderless utility line that renders on every page.
+- **Seamless create form.** The floating elevated card is gone — the form is now set directly into the page as one continuous "sheet" alongside the stats ledger, joined by a single hairline divider. New "Drop a secret." hero, grouped fields under shared eyebrow labels, a compact Text/File switch, a tinted secret well, "Delete after first view" toggle, and an integrated "receipt" success panel.
+- File mode now accepts **drag-and-drop** onto the well (previously the "drop it here" label was decorative).
+
+### Fixed
+- **Dark mode now paints a dark ground.** Previously the global stylesheet forced `.v-application { background: transparent !important }` over a hard-coded light gradient, so the dark theme's background never actually applied. The page now uses the Vuetify theme background token with a theme-aware radial wash, and the mobile browser chrome color (`theme-color`) tracks the active theme.
+
 ## [1.1.0]
 
 ### Added

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,10 @@
     <meta name="keywords" content="secure, secret sharing, file sharing, encryption, one-time link" />
     <meta name="author" content="GopherDrop Community" />
 
+    <!-- Theme color for browser UI, kept in sync with the app's active
+         (localStorage-driven) theme by App.vue, not the OS preference. -->
+    <meta name="theme-color" content="#FBFAFE" />
+
     <!-- Favicon -->
     <link rel="icon" href="/src/assets/Images/favicon.ico" type="image/x-icon" />
 

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -2,33 +2,38 @@
   <v-app>
     <v-main class="d-flex flex-column">
       <v-container fluid class="pa-0 flex-grow-1">
-        <v-app-bar color="transparent" flat class="px-4">
-          <v-toolbar-title>
-            <router-link to="/" class="logo-link animate__animated animate__pulse" @click="requestFormReset">
-              <img src="./assets/Images/logo.png" alt="Logo" height="40" />
+        <div class="gd-utility-wrap">
+          <div class="gd-utility-line">
+            <router-link to="/" class="gd-brand" @click="requestFormReset">
+              <img src="./assets/Images/logo.png" alt="" height="24" width="24" />
+              <span class="gd-brand__word font-display">GopherDrop</span>
             </router-link>
-          </v-toolbar-title>
-          <v-spacer></v-spacer>
-          <v-btn to="/" text class="animate__animated animate__fadeIn" @click="requestFormReset" rounded>
-            <v-icon left>mdi-plus</v-icon> Create New
-          </v-btn>
-          <v-tooltip :text="isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'">
-            <template v-slot:activator="{ props }">
-              <v-btn v-bind="props" icon @click="toggleTheme" class="ml-2">
-                <v-icon>{{ isDarkMode ? 'mdi-weather-sunny' : 'mdi-weather-night' }}</v-icon>
-              </v-btn>
-            </template>
-          </v-tooltip>
-        </v-app-bar>
+
+            <v-tooltip :text="isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'">
+              <template v-slot:activator="{ props }">
+                <v-btn
+                  v-bind="props"
+                  variant="text"
+                  density="comfortable"
+                  icon
+                  :aria-label="isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'"
+                  @click="toggleTheme"
+                >
+                  <v-icon>{{ isDarkMode ? 'mdi-weather-sunny' : 'mdi-weather-night' }}</v-icon>
+                </v-btn>
+              </template>
+            </v-tooltip>
+          </div>
+        </div>
 
         <v-container class="mt-4">
           <router-view />
         </v-container>
       </v-container>
 
-      <v-footer color="transparent" class="justify-center mt-8 pa-4">
+      <v-footer color="transparent" class="justify-center gd-footer pa-4">
         <span>
-          © {{ new Date().getFullYear() }} GopherDrop |
+          © {{ new Date().getFullYear() }} GopherDrop | self-hosted & open source |
           <a
             href="https://github.com/kek-Sec/gopherdrop"
             target="_blank"
@@ -54,12 +59,28 @@ import { useTheme } from 'vuetify';
 const themeInstance = useTheme();
 const isDarkMode = computed(() => themeInstance.global.current.value.dark);
 
+// Ground color per theme, kept in sync with the <meta name="theme-color">
+// so the mobile browser chrome matches the app's active theme (which is
+// driven by localStorage, not the OS prefers-color-scheme).
+const themeColors = {
+  customLightTheme: '#FBFAFE',
+  customDarkTheme: '#141218',
+};
+
+function updateThemeColorMeta(themeName) {
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) {
+    meta.setAttribute('content', themeColors[themeName] || themeColors.customLightTheme);
+  }
+}
+
 // On component mount, check localStorage for a saved theme
 onMounted(() => {
   const savedTheme = localStorage.getItem('theme');
   if (savedTheme) {
     themeInstance.global.name.value = savedTheme;
   }
+  updateThemeColorMeta(themeInstance.global.name.value);
 });
 
 function toggleTheme() {
@@ -67,6 +88,7 @@ function toggleTheme() {
   themeInstance.global.name.value = newTheme;
   // Save the new theme preference to localStorage
   localStorage.setItem('theme', newTheme);
+  updateThemeColorMeta(newTheme);
 }
 
 /**
@@ -83,15 +105,42 @@ function requestFormReset() {
   font-weight: 500;
 }
 
-.logo-link {
-  display: inline-block;
-  text-decoration: none;
-  vertical-align: middle;
-}
-
 .v-main {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+}
+
+.gd-utility-wrap {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.gd-utility-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+}
+
+.gd-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+}
+
+.gd-brand__word {
+  font-weight: 600;
+  font-size: 1rem;
+  color: rgba(var(--v-theme-on-surface), 0.85);
+}
+
+.gd-footer {
+  margin-top: 64px;
+  border-top: 1px solid rgba(var(--v-theme-on-surface), 0.1);
+  font-size: 0.8125rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
 }
 </style>

--- a/ui/src/assets/style.css
+++ b/ui/src/assets/style.css
@@ -6,19 +6,20 @@ html, body {
     margin: 0;
     padding: 0;
     font-family: "Inter Variable", Inter, Arial, sans-serif;
-    color: #333;
-    background: #f4f4f9; /* Fallback background */
 }
 
-/* Add a subtle gradient background */
-body {
-    background: linear-gradient(180deg, rgba(232,222,248,0.3) 0%, rgba(255,255,255,1) 30%);
-}
-
+/* Let Vuetify's theme drive the ground color (so dark mode gets a dark
+   background instead of being forced transparent onto a light body), and
+   layer a non-interactive radial wash on top of it. Both are painted directly
+   on .v-application — a negative-z-index ::before would render *behind*
+   Vuetify's own opaque .v-application background and never show. Driven by
+   theme tokens, so it flips automatically with light/dark. */
 .v-application {
-    background: transparent !important;
+    background:
+        radial-gradient(1100px 480px at 18% -12%, rgba(var(--v-theme-primary), 0.06), transparent 60%),
+        rgb(var(--v-theme-background)) !important;
+    background-attachment: fixed;
 }
-
 
 a {
     color: #6750A4; /* Using the new primary color */
@@ -56,19 +57,6 @@ a:hover {
     to { opacity: 1; }
 }
 
-@keyframes gd-pulse {
-    0% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-    100% { transform: scale(1); }
-}
-
-@keyframes gd-bounceIn {
-    0% { opacity: 0; transform: scale(0.9); }
-    50% { opacity: 1; transform: scale(1.03); }
-    70% { transform: scale(0.98); }
-    100% { transform: scale(1); }
-}
-
 .animate__animated {
     animation-duration: .8s;
     animation-fill-mode: both;
@@ -78,12 +66,14 @@ a:hover {
     animation-name: gd-fadeIn;
 }
 
-.animate__pulse {
-    animation-name: gd-pulse;
-}
-
-.animate__bounceIn {
-    animation-name: gd-bounceIn;
+/* Eyebrow label style shared by the ledger and the create form, so both
+   speak the same visual language. */
+.gd-eyebrow {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: rgba(var(--v-theme-on-surface), 0.6);
 }
 
 /* Local motion keyframes for the revamp */

--- a/ui/src/components/PasswordInput.vue
+++ b/ui/src/components/PasswordInput.vue
@@ -5,19 +5,35 @@
     :model-value="modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
     variant="outlined"
+    density="comfortable"
     prepend-inner-icon="mdi-lock"
   >
     <template v-slot:append-inner>
       <v-tooltip text="Toggle Password Visibility">
         <template v-slot:activator="{ props }">
-          <v-btn icon v-bind="props" @click="showPassword = !showPassword" size="small">
+          <v-btn
+            variant="text"
+            icon
+            v-bind="props"
+            @click="showPassword = !showPassword"
+            size="small"
+            :aria-label="showPassword ? 'Hide password' : 'Show password'"
+          >
             <v-icon>{{ showPassword ? 'mdi-eye-off' : 'mdi-eye' }}</v-icon>
           </v-btn>
         </template>
       </v-tooltip>
       <v-tooltip text="Generate Random Password">
         <template v-slot:activator="{ props }">
-          <v-btn icon color="primary" v-bind="props" @click="generateNewPassword" size="small" style="margin-left: 4px">
+          <v-btn
+            variant="text"
+            icon
+            v-bind="props"
+            @click="generateNewPassword"
+            size="small"
+            style="margin-left: 4px"
+            aria-label="Generate random password"
+          >
             <v-icon>mdi-refresh</v-icon>
           </v-btn>
         </template>

--- a/ui/src/components/SecretResult.vue
+++ b/ui/src/components/SecretResult.vue
@@ -1,42 +1,142 @@
 <template>
-  <v-alert type="success" class="mt-6 animate__animated animate__fadeIn" variant="tonal">
-    <div class="text-h6 mb-2">Secret Created!</div>
-    <p>Share this link to view the secret:</p>
-    <div class="d-flex align-center mt-2 pa-2" style="background-color: rgba(var(--v-theme-on-surface), 0.05); border-radius: 8px;">
-      <span class="mr-2 text-truncate">{{ link }}</span>
-      <v-spacer></v-spacer>
-      <v-tooltip text="Copy Link to Clipboard">
-        <template v-slot:activator="{ props }">
-          <v-btn icon v-bind="props" @click="copyLink">
-            <v-icon>mdi-content-copy</v-icon>
-          </v-btn>
-        </template>
-      </v-tooltip>
-    </div>
+  <div class="gd-receipt gd-rise">
+    <div class="gd-receipt__rule" aria-hidden="true"></div>
 
-    <v-btn color="success" variant="outlined" class="mt-4" @click="$emit('create-another')">
-      Create another
-    </v-btn>
+    <div class="gd-receipt__body">
+      <div class="gd-receipt__heading font-display">Secret created</div>
+      <p class="gd-receipt__hint">Share this link to view the secret:</p>
+
+      <div class="gd-receipt__link-row">
+        <span class="gd-receipt__link">{{ link }}</span>
+        <v-tooltip text="Copy Link to Clipboard">
+          <template v-slot:activator="{ props }">
+            <v-btn
+              variant="text"
+              icon
+              v-bind="props"
+              @click="copyLink"
+              size="small"
+              aria-label="Copy link to clipboard"
+            >
+              <v-icon>mdi-content-copy</v-icon>
+            </v-btn>
+          </template>
+        </v-tooltip>
+      </div>
+
+      <p v-if="recapText" class="gd-receipt__recap">{{ recapText }}</p>
+
+      <v-btn
+        color="primary"
+        variant="flat"
+        class="mt-4 gd-receipt__cta"
+        height="44"
+        @click="$emit('create-another')"
+      >
+        Create another
+      </v-btn>
+    </div>
 
     <v-snackbar v-model="snackbar" timeout="2000" color="success">
       Link copied to clipboard!
     </v-snackbar>
-  </v-alert>
+  </div>
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
 const props = defineProps({
   link: { type: String, required: true },
+  // Optional recap props. When absent (or expires is falsy) the recap
+  // line is simply omitted and the receipt still renders cleanly.
+  expires: { type: String, default: null },
+  oneTime: { type: Boolean, default: false },
 });
 
 defineEmits(['create-another']);
 
 const snackbar = ref(false);
 
+const recapText = computed(() => {
+  if (!props.expires) return null;
+  return props.oneTime
+    ? `Expires in ${props.expires} · deletes after first view`
+    : `Expires in ${props.expires}`;
+});
+
 function copyLink() {
   navigator.clipboard.writeText(props.link);
   snackbar.value = true;
 }
 </script>
+
+<style scoped>
+.gd-receipt {
+  position: relative;
+  display: flex;
+  margin-top: 24px;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.14);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.gd-receipt__rule {
+  width: 4px;
+  flex-shrink: 0;
+  background: rgb(var(--v-theme-success));
+}
+
+.gd-receipt__body {
+  flex: 1;
+  min-width: 0;
+  padding: 20px 24px;
+}
+
+.gd-receipt__heading {
+  font-size: 1.125rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.gd-receipt__hint {
+  margin: 0 0 8px;
+  font-size: 0.875rem;
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+.gd-receipt__link-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 8px 8px 12px;
+  background: rgba(var(--v-theme-on-surface), 0.05);
+  border-radius: 8px;
+}
+
+.gd-receipt__link {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.8125rem;
+}
+
+.gd-receipt__recap {
+  margin: 12px 0 0;
+  font-size: 0.8125rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+.gd-receipt__cta {
+  border-radius: 10px;
+}
+
+@media (max-width: 599px) {
+  .gd-receipt__body {
+    padding: 16px;
+  }
+}
+</style>

--- a/ui/src/components/stats/ServerLedger.vue
+++ b/ui/src/components/stats/ServerLedger.vue
@@ -9,7 +9,7 @@
   </div>
 
   <div v-else-if="stats" class="server-ledger gd-fade-in">
-    <div class="server-ledger__eyebrow font-display">THIS SERVER</div>
+    <div class="server-ledger__eyebrow gd-eyebrow">THIS SERVER</div>
 
     <StatTile
       class="server-ledger__hero"
@@ -141,11 +141,13 @@ defineExpose({ tick });
 }
 
 .server-ledger__eyebrow {
-  font-size: 0.75rem;
+  /* Matches the shared .gd-eyebrow spec so this label speaks the same
+     language as StatTile's own eyebrows and the page H1's utility line. */
+  font-size: 0.6875rem;
   font-weight: 600;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: rgba(var(--v-theme-on-surface), 0.55);
+  color: rgba(var(--v-theme-on-surface), 0.6);
 }
 
 .server-ledger__divider {
@@ -163,6 +165,8 @@ defineExpose({ tick });
 }
 
 .server-ledger__hero :deep(.stat-tile__value) {
+  /* Sit below the new page H1 in the visual hierarchy (was 3rem). */
+  font-size: 2.5rem;
   transition: text-shadow 0.4s ease, color 0.4s ease;
 }
 

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -21,7 +21,7 @@ const customLightTheme = {
   colors: {
     primary: '#6750A4', // A modern purple
     secondary: '#E8DEF8', // A light, complementary purple
-    background: '#FFFFFF',
+    background: '#FBFAFE',
     surface: '#FEF7FF', // Off-white for cards and surfaces
     info: '#6750A4', // Using primary color for info state for consistency
     error: '#B3261E',

--- a/ui/src/pages/Create.vue
+++ b/ui/src/pages/Create.vue
@@ -1,90 +1,137 @@
 <template>
   <v-container class="create-page">
-    <div class="create-page__headline">
-      <h1 class="font-display text-h4 text-md-h3 font-weight-bold">Share secrets that vanish.</h1>
-      <p class="create-page__subhead">Encrypted on this server. Delivered once. Then destroyed.</p>
-    </div>
-
     <v-row class="create-page__row">
       <v-col cols="12" md="7" order="1">
-        <v-card class="pa-4 pa-md-8 animate__animated animate__fadeIn" elevation="6" rounded="lg">
-          <v-card-title class="text-h5 text-md-h4 font-weight-bold text-center mb-4">Create a New Secret 🔑</v-card-title>
-          <v-card-text>
-            <v-form @submit.prevent="handleSubmit">
-              <v-btn-toggle
-                v-model="type"
-                mandatory
-                class="mb-4 d-flex justify-center"
-                color="primary"
-                rounded
-                group
+        <div class="create-page__title gd-rise">
+          <h1 class="font-display create-page__h1">Drop a secret.</h1>
+          <p class="create-page__tagline">Encrypted on this server &middot; delivered once &middot; then destroyed.</p>
+        </div>
+
+        <v-form v-if="!resultHash" @submit.prevent="handleSubmit" class="create-page__form gd-rise">
+          <div class="gd-eyebrow-row">
+            <span class="gd-eyebrow">Your secret</span>
+
+            <v-btn-toggle
+              v-model="type"
+              mandatory
+              density="compact"
+              divided
+              class="gd-mode-toggle"
+            >
+              <v-btn
+                value="text"
+                size="small"
+                :variant="type === 'text' ? 'tonal' : 'outlined'"
+                :color="type === 'text' ? 'primary' : undefined"
               >
-                <v-btn value="text" class="px-6" rounded>
-                  <v-icon left>mdi-text</v-icon> Text
-                </v-btn>
-                <v-btn value="file" class="px-6" rounded>
-                  <v-icon left>mdi-file</v-icon> File
-                </v-btn>
-              </v-btn-toggle>
+                <v-icon start size="16">mdi-text</v-icon> Text
+              </v-btn>
+              <v-btn
+                value="file"
+                size="small"
+                :variant="type === 'file' ? 'tonal' : 'outlined'"
+                :color="type === 'file' ? 'primary' : undefined"
+              >
+                <v-icon start size="16">mdi-file</v-icon> File
+              </v-btn>
+            </v-btn-toggle>
+          </div>
 
-              <v-textarea
-                v-if="type === 'text'"
-                label="Text Secret"
-                v-model="textSecret"
-                required
-                variant="outlined"
-                rows="4"
-              ></v-textarea>
+          <v-textarea
+            v-if="type === 'text'"
+            v-model="textSecret"
+            required
+            variant="plain"
+            auto-grow
+            no-resize
+            rows="5"
+            hide-details
+            placeholder="Paste the secret. It never leaves this server unencrypted."
+            class="gd-secret-well"
+          ></v-textarea>
 
-              <v-file-input
-                v-if="type === 'file'"
-                label="Select File"
-                prepend-icon="mdi-upload"
-                v-model="files"
-                show-size
-                required
-                variant="outlined"
-              ></v-file-input>
+          <div
+            v-if="type === 'file'"
+            @dragover.prevent
+            @dragenter.prevent
+            @drop.prevent="onFileDrop"
+          >
+            <v-file-input
+              v-model="files"
+              label="Choose a file or drop it here"
+              variant="plain"
+              hide-details
+              show-size
+              required
+              class="gd-secret-well gd-file-well"
+            >
+              <template v-slot:prepend-inner>
+                <v-icon icon="mdi-tray-arrow-up" class="gd-file-well__icon" />
+              </template>
+            </v-file-input>
+          </div>
 
-              <PasswordInput v-model="password" class="mt-2" />
+          <div class="gd-eyebrow create-page__group-label">Delivery</div>
 
-              <v-select
-                label="Expiration"
-                v-model="expires"
-                :items="expirationOptions"
-                required
-                variant="outlined"
-                class="mt-2"
-              ></v-select>
+          <PasswordInput v-model="password" class="mb-4" />
 
-              <v-checkbox
-                v-model="oneTime"
-                label="One-Time Retrieval"
-                color="primary"
-                class="mt-2"
-              ></v-checkbox>
+          <div class="gd-delivery-row">
+            <v-select
+              label="Expires in"
+              v-model="expires"
+              :items="expirationOptions"
+              required
+              variant="outlined"
+              density="comfortable"
+              hide-details
+              class="gd-delivery-row__select"
+            ></v-select>
 
-              <v-btn type="submit" color="primary" class="mt-4" block large rounded x-large height="50">Create Secret</v-btn>
+            <v-switch
+              v-model="oneTime"
+              label="Delete after first view"
+              color="primary"
+              inset
+              hide-details
+              class="gd-delivery-row__switch"
+            ></v-switch>
+          </div>
 
-              <v-alert v-if="errorMessage" type="error" class="mt-4 animate__animated animate__bounceIn" variant="tonal">
-                {{ errorMessage }}
-              </v-alert>
-            </v-form>
+          <v-btn
+            type="submit"
+            color="primary"
+            variant="flat"
+            block
+            height="48"
+            class="create-page__submit"
+          >
+            Create secret
+          </v-btn>
 
-            <SecretResult
-              v-if="resultHash"
-              :link="`${baseUrl}/view/${resultHash}`"
-              @create-another="resetForm"
-            />
+          <v-alert
+            v-if="errorMessage"
+            type="error"
+            variant="tonal"
+            class="mt-4 gd-rise"
+          >
+            {{ errorMessage }}
+          </v-alert>
+        </v-form>
 
-            <v-overlay v-model="loading" class="align-center justify-center">
-              <v-progress-circular indeterminate color="primary" size="64"></v-progress-circular>
-            </v-overlay>
-          </v-card-text>
-        </v-card>
+        <SecretResult
+          v-if="resultHash"
+          :link="`${baseUrl}/view/${resultHash}`"
+          :expires="createdExpiresLabel"
+          :one-time="createdOneTime"
+          @create-another="resetForm"
+        />
+
+        <v-overlay v-model="loading" class="align-center justify-center">
+          <v-progress-circular indeterminate color="primary" size="64"></v-progress-circular>
+        </v-overlay>
       </v-col>
 
-      <v-col cols="12" md="5" order="2">
+      <v-col cols="12" md="5" order="2" class="create-page__ledger-col gd-rise">
         <ServerLedger ref="ledger" />
       </v-col>
     </v-row>
@@ -92,7 +139,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { createSend } from '../services/api.js';
 import PasswordInput from '../components/PasswordInput.vue';
 import SecretResult from '../components/SecretResult.vue';
@@ -112,6 +159,11 @@ const baseUrl = window.location.origin;
 const loading = ref(false);
 const ledger = ref(null);
 
+// Captured at the moment of a successful submit (before the fields are
+// cleared) so SecretResult can render an accurate recap line.
+const createdExpires = ref('');
+const createdOneTime = ref(false);
+
 const expirationOptions = [
   { title: '1 Hour', value: '1h' },
   { title: '6 Hours', value: '6h' },
@@ -120,6 +172,11 @@ const expirationOptions = [
   { title: '3 Days', value: '72h' },
   { title: '1 Week', value: '168h' }
 ];
+
+const createdExpiresLabel = computed(() => {
+  const match = expirationOptions.find((option) => option.value === createdExpires.value);
+  return match ? match.title : createdExpires.value;
+});
 
 function resetForm() {
   type.value = 'text';
@@ -136,6 +193,15 @@ function resetForm() {
 watch(() => formStore.resetCounter, () => {
   resetForm();
 });
+
+// Accept a file dropped anywhere on the file well. Keeps files.value an
+// array-with-a-File, matching what handleSubmit expects.
+function onFileDrop(event) {
+  const dropped = event.dataTransfer?.files;
+  if (dropped && dropped.length) {
+    files.value = [dropped[0]];
+  }
+}
 
 async function handleSubmit() {
   errorMessage.value = '';
@@ -174,9 +240,11 @@ async function handleSubmit() {
 
   try {
     const result = await createSend(formData);
-    const createdType = type.value;
+    const createdTypeValue = type.value;
+    createdExpires.value = expires.value;
+    createdOneTime.value = oneTime.value;
     resultHash.value = result.hash;
-    ledger.value?.tick(createdType);
+    ledger.value?.tick(createdTypeValue);
     // Clear form inputs but keep the result hash visible
     type.value = 'text';
     textSecret.value = '';
@@ -197,21 +265,132 @@ async function handleSubmit() {
   min-height: 85vh;
 }
 
-.create-page__headline {
-  text-align: center;
-  margin-bottom: 24px;
-}
-
-.create-page__subhead {
-  color: rgba(var(--v-theme-on-surface), 0.7);
-  margin-top: 4px;
-}
-
 .create-page__row {
   align-items: flex-start;
 }
 
-.v-card {
-  width: 100%;
+.create-page__title {
+  margin-bottom: 40px;
+}
+
+.create-page__h1 {
+  font-weight: 700;
+  font-size: 1.75rem;
+  line-height: 1.2;
+  text-align: left;
+  margin: 0;
+}
+
+@media (min-width: 960px) {
+  .create-page__h1 {
+    font-size: 2rem;
+  }
+}
+
+.create-page__tagline {
+  margin: 8px 0 0;
+  font-size: 0.9375rem;
+  color: rgba(var(--v-theme-on-surface), 0.65);
+}
+
+.create-page__form {
+  animation-delay: 60ms;
+}
+
+.create-page__ledger-col {
+  animation-delay: 120ms;
+  padding-top: 32px;
+}
+
+@media (min-width: 960px) {
+  .create-page__ledger-col {
+    padding-top: 0;
+    padding-left: 48px;
+    border-left: 1px solid rgba(var(--v-theme-on-surface), 0.10);
+  }
+}
+
+@media (max-width: 959.98px) {
+  .create-page__ledger-col {
+    margin-top: 8px;
+    border-top: 1px solid rgba(var(--v-theme-on-surface), 0.10);
+  }
+}
+
+/* "YOUR SECRET" eyebrow + Text|File segmented control */
+.gd-eyebrow-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.create-page__group-label {
+  margin: 24px 0 8px;
+}
+
+.gd-mode-toggle :deep(.v-btn) {
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+/* Shared footprint for text + file wells so switching modes never jumps
+   the layout. */
+.gd-secret-well :deep(.v-field) {
+  min-height: 160px;
+  background: rgba(var(--v-theme-primary), 0.04);
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.14);
+  border-radius: 10px;
+  box-shadow: none;
+}
+
+.gd-secret-well :deep(.v-field.v-field--focused) {
+  border: 1.5px solid rgb(var(--v-theme-primary));
+  box-shadow: none;
+}
+
+.gd-secret-well :deep(textarea) {
+  padding: 12px;
+}
+
+.gd-file-well :deep(.v-field__input) {
+  align-items: center;
+}
+
+.gd-file-well__icon {
+  color: rgba(var(--v-theme-on-surface), 0.5);
+}
+
+.gd-file-well :deep(.v-chip) {
+  background: rgba(var(--v-theme-chart-file), 0.14);
+  color: rgb(var(--v-theme-chart-file));
+}
+
+.gd-delivery-row {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 8px;
+}
+
+.gd-delivery-row__select {
+  flex: 1;
+}
+
+.gd-delivery-row__switch {
+  flex-shrink: 0;
+}
+
+@media (max-width: 599px) {
+  .gd-delivery-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+}
+
+.create-page__submit {
+  margin-top: 24px;
+  border-radius: 10px;
 }
 </style>

--- a/version.yaml
+++ b/version.yaml
@@ -1,2 +1,2 @@
 #Application version following https://semver.org/
-version: 1.1.0
+version: 1.2.0


### PR DESCRIPTION
## Overview

A landing-page restyle following the same **fable → opus → sonnet swarm → opus adversary** flow. The brief: **remove the header, get straight to the point, and make the create panel feel seamless with the page** — full artistic freedom for the design pass.

Concept ("The Manifest", from the fable design agent): the whole page is **one continuous sheet** — the create form is the "slip" you fill in, the server ledger is the running record, joined by a single hairline. No app-bar, no floating card, no chrome.

## Changes

### Headerless & straight to the point
- **Removed the top `v-app-bar` entirely.** The brand wordmark (still the "start over" / reset action) and the theme toggle now live in a quiet, borderless **utility line** rendered on every route — so `View` and `404` keep a way home.
- New left-aligned **"Drop a secret."** hero replaces the oversized centered headline; the form is usable above the fold.

### Seamless create form
- The elevated `v-card` is **gone** — the form sits directly on the page surface. Fields are grouped under shared `.gd-eyebrow` labels that match the ledger's vocabulary, so the two columns read as one composition (divided by a single hairline).
- Compact **Text/File segmented switch**, a tinted "secret well" with a shared footprint (no layout jump between modes), **drag-and-drop** file support, a **"Delete after first view"** switch, plain-text password affordances, and an integrated **receipt-style** success panel (with an optional expiry/one-time recap).

### Fixed: dark mode never painted a dark ground 🐛
- The global stylesheet forced `.v-application { background: transparent !important }` over a **hard-coded light gradient**, so `customDarkTheme`'s `#141218` background never applied. The page now uses the Vuetify **theme background token** plus a **theme-aware radial wash** (driven by `--v-theme-primary`), and the mobile `theme-color` meta tracks the active (localStorage) theme rather than the OS preference.

## Adversary review outcome

The opus adversary returned **shipReady: true** (no critical/high). Fixes applied from its findings:
- **[medium]** the radial wash was occluded behind Vuetify's opaque `.v-application` background (negative-z-index `::before`) — repainted it as a background layer on `.v-application` itself so it actually renders.
- **[low]** "drop it here" was a dead affordance → wired a real drop handler.
- **[low]** duplicate `min-height` on the file well caused a mode-switch layout jump → removed.
- **[low]** `theme-color` metas were OS-gated while the app theme is localStorage-driven → now synced from JS.
- **[low]** removed a dead `createdType` ref.

## Verification

- `npm run build` ✅ (self-hosted fonts, no external CDN reintroduced)
- Adversary confirmed: header gone but toggle reachable + `localStorage` persistence intact, `formStore.triggerReset()` still wired to the wordmark, `handleSubmit`/`resetForm`/reset watcher and the ledger `tick()` delight path preserved verbatim, `View`/`404` shells still render.

Bumps version `1.1.0 → 1.2.0`.