### PR TITLE
fix(ui): stop secret textarea cropping the first line of text

### DIFF
--- a/ui/src/pages/Create.vue
+++ b/ui/src/pages/Create.vue
@@ -353,6 +353,16 @@ async function handleSubmit() {
   padding: 12px;
 }
 
+/* Vuetify fades the top of a textarea with a mask so scrolled content slips
+   under a floating label. This well has no label (placeholder only), and the
+   mask's fade zone (~14–24px on the default density) sits right where our 12px
+   padding places the first line — cropping its top. Drop the mask so text
+   renders in full. */
+.gd-secret-well :deep(textarea.v-field__input) {
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
 .gd-file-well :deep(.v-field__input) {
   align-items: center;
 }


### PR DESCRIPTION
## Problem

The **Your secret** text well clips the top of the first line of typed text (e.g. `test123` renders with its tops shaved off).

![before](https://user-images.githubusercontent.com/placeholder) <!-- reproduced from reporter screenshot -->

## Root cause

Vuetify applies a top `mask-image` to every `v-textarea` so that content scrolling upward fades out under the floating label:

```css
.v-textarea .v-field__input {
  mask-image: linear-gradient(to bottom,
    transparent,
    transparent calc(var(--v-field-padding-top) + var(--v-input-padding-top) - 6px),
    black        calc(var(--v-field-padding-top) + var(--v-input-padding-top) + 4px));
}
```

On the default density this resolves to `--v-field-padding-top: 4px` + `--v-input-padding-top: 16px`, so the fade zone runs **~14px → 24px** from the top of the textarea.

The well is `variant="plain"` with **no label** (placeholder only) and a custom `padding: 12px`. That puts the first line of text at 12px — inside the still-transparent part of the mask — so its top is clipped.

## Fix

Because the well has no floating label, the top fade serves no purpose. Disable the mask on this textarea so text renders in full:

```css
.gd-secret-well :deep(textarea.v-field__input) {
  -webkit-mask-image: none;
  mask-image: none;
}
```

Scoped to `.gd-secret-well`, so no other Vuetify textarea is affected.

## Testing

- `npm run build` passes.
- Verified via CSS-mechanism trace: the 12px text baseline falls inside the 14–24px mask fade, which exactly accounts for the reported crop; removing the mask lifts it. No functional downside — auto-grow is unaffected (the sizer `<textarea>` shares the same padding).