### PR TITLE
feat(ui): animate the server ledger & make its charts more meaningful

### DIFF
--- a/ui/src/assets/style.css
+++ b/ui/src/assets/style.css
@@ -95,6 +95,40 @@ a:hover {
     animation: gd-fade-in 300ms ease-out both;
 }
 
+/* Ledger reveal vocabulary — a small kit the stat components share so the
+   whole right column materializes as one orchestrated sequence rather than a
+   pile of independent effects. */
+
+/* Bars rising from the baseline (scaled from their own bottom edge). */
+@keyframes gd-bar-grow {
+    from { transform: scaleY(0); opacity: 0; }
+    to { transform: scaleY(1); opacity: 1; }
+}
+
+/* Meters / split bars sweeping in from the left. */
+@keyframes gd-fill-x {
+    from { transform: scaleX(0); }
+    to { transform: scaleX(1); }
+}
+
+/* A light sweep travelling across a progress fill, so momentum reads as
+   ongoing rather than finished. */
+@keyframes gd-shimmer {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(220%); }
+}
+
+/* The "held right now" pulse — a slow breathing ring, not a blink. */
+@keyframes gd-pulse {
+    0%, 100% { transform: scale(1); opacity: 0.9; }
+    50% { transform: scale(1.55); opacity: 0.25; }
+}
+
+.gd-rise--1 { animation-delay: 60ms; }
+.gd-rise--2 { animation-delay: 120ms; }
+.gd-rise--3 { animation-delay: 180ms; }
+.gd-rise--4 { animation-delay: 240ms; }
+
 @media (prefers-reduced-motion: reduce) {
     .animate__animated,
     .gd-rise,

--- a/ui/src/components/stats/ActivityChart.vue
+++ b/ui/src/components/stats/ActivityChart.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="activity-chart" ref="wrapRef">
+    <div class="activity-chart__header">
+      <span class="activity-chart__title gd-eyebrow">Daily activity</span>
+      <span class="activity-chart__summary">{{ summaryText }}</span>
+    </div>
+
+    <div class="activity-chart__plot">
     <svg
       class="activity-chart__svg"
       :viewBox="`0 0 ${viewBoxWidth} ${viewBoxHeight}`"
@@ -43,7 +49,10 @@
       <g v-for="(day, i) in daily" :key="day.date || i">
         <g
           class="activity-chart__col"
-          :class="{ 'activity-chart__col--hover': hoveredIndex === i }"
+          :class="{
+            'activity-chart__col--hover': hoveredIndex === i,
+            'activity-chart__col--today': i === daily.length - 1 && !isEmpty,
+          }"
           :style="colStyle(i)"
         >
           <template v-if="!isEmpty">
@@ -94,7 +103,28 @@
           @blur="hoveredIndex = null"
         />
       </g>
+
+      <!-- 7-day momentum: a trailing average riding over the bars, so a run
+           of busy days reads as a rising trend and not just tall columns.
+           pathLength normalizes the length so the draw-in works regardless of
+           how many days are plotted. -->
+      <path
+        v-if="showTrend"
+        :d="trendPath"
+        class="activity-chart__trend"
+        pathLength="1"
+        fill="none"
+      />
     </svg>
+
+    <!-- "Now" marker for the trend, as HTML so the non-uniform viewBox scaling
+         can't squash it into an ellipse. -->
+    <div
+      v-if="showTrend"
+      class="activity-chart__trend-head"
+      :style="trendHeadStyle"
+      aria-hidden="true"
+    />
 
     <div
       v-if="hoveredIndex !== null"
@@ -102,6 +132,12 @@
       :style="tooltipStyle"
     >
       {{ dayTooltip(daily[hoveredIndex]) }}
+    </div>
+    </div>
+
+    <div v-if="!isEmpty" class="activity-chart__axis">
+      <span>{{ firstDateLabel }}</span>
+      <span class="activity-chart__axis-today">Today</span>
     </div>
 
     <div v-if="isEmpty" class="activity-chart__caption">Activity will appear here</div>
@@ -262,10 +298,115 @@ const tooltipStyle = computed(() => {
     top: `${(topPad / viewBoxHeight) * 100}%`,
   };
 });
+
+/* ---- Period summary + momentum trend ---- */
+
+const dayTotals = computed(() =>
+  props.daily.map((d) => (Number(d?.texts) || 0) + (Number(d?.files) || 0))
+);
+
+const peak = computed(() => {
+  let value = 0;
+  let index = -1;
+  dayTotals.value.forEach((total, i) => {
+    if (total > value) {
+      value = total;
+      index = i;
+    }
+  });
+  return { value, index };
+});
+
+// One-line context so the chart states what it's showing rather than leaving
+// the reader to eyeball it: the period's volume and its busiest day.
+const summaryText = computed(() => {
+  if (isEmpty.value) return 'No drops yet';
+  const total = totals.value.all;
+  const noun = total === 1 ? 'secret' : 'secrets';
+  const peakDay = formatShortDate(props.daily[peak.value.index]?.date);
+  return `${compactNumber(total)} ${noun} · peak ${peak.value.value}${peakDay ? ` on ${peakDay}` : ''}`;
+});
+
+// Trailing average (up to a 7-day window) sampled at each day's centre. Riding
+// it over the raw bars turns a cluster of busy days into a visible upswing.
+const trendPoints = computed(() => {
+  const totalsArr = dayTotals.value;
+  const n = totalsArr.length;
+  if (n === 0) return [];
+  const window = Math.min(7, n);
+  const points = [];
+  for (let i = 0; i < n; i += 1) {
+    let sum = 0;
+    let count = 0;
+    for (let j = Math.max(0, i - window + 1); j <= i; j += 1) {
+      sum += totalsArr[j];
+      count += 1;
+    }
+    const avg = count > 0 ? sum / count : 0;
+    points.push({ x: slotX(i) + slotWidth.value / 2, y: yForValue(avg) });
+  }
+  return points;
+});
+
+// Needs at least a few days of real activity to mean anything.
+const showTrend = computed(() => !isEmpty.value && trendPoints.value.length >= 3);
+
+// Smooth cubic through the points with horizontal tangents at each node — a
+// calm curve that reads as a trend line, not a jagged connect-the-dots.
+const trendPath = computed(() => {
+  const pts = trendPoints.value;
+  if (pts.length < 2) return '';
+  let d = `M${pts[0].x},${pts[0].y}`;
+  for (let i = 1; i < pts.length; i += 1) {
+    const midX = (pts[i - 1].x + pts[i].x) / 2;
+    d += ` C${midX},${pts[i - 1].y} ${midX},${pts[i].y} ${pts[i].x},${pts[i].y}`;
+  }
+  return d;
+});
+
+function formatShortDate(dateStr) {
+  if (!dateStr) return '';
+  const [y, m, d] = String(dateStr).split('-').map(Number);
+  if (!y || !m || !d) return '';
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+const firstDateLabel = computed(() => formatShortDate(props.daily[0]?.date));
+
+const trendHeadStyle = computed(() => {
+  const pts = trendPoints.value;
+  if (!pts.length) return {};
+  const last = pts[pts.length - 1];
+  return {
+    left: `${(last.x / viewBoxWidth) * 100}%`,
+    top: `${(last.y / viewBoxHeight) * 100}%`,
+  };
+});
 </script>
 
 <style scoped>
 .activity-chart {
+  position: relative;
+  width: 100%;
+}
+
+.activity-chart__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.activity-chart__summary {
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.activity-chart__plot {
   position: relative;
   width: 100%;
 }
@@ -335,6 +476,41 @@ const tooltipStyle = computed(() => {
   filter: drop-shadow(0 0 5px rgba(var(--v-theme-chart-text), 0.45));
 }
 
+/* Today reads as "live": a gentle standing glow, so the most recent day is
+   findable at a glance without a hard outline. */
+.activity-chart__col--today {
+  filter: drop-shadow(0 0 4px rgba(var(--v-theme-on-surface), 0.28));
+}
+
+/* Momentum line: a calm near-neutral stroke that sits above the coloured bars
+   as an analytical overlay, drawing itself in left-to-right after the bars. */
+.activity-chart__trend {
+  stroke: rgba(var(--v-theme-on-surface), 0.6);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  animation: gd-draw 900ms ease-out 260ms forwards;
+}
+
+@keyframes gd-draw {
+  to { stroke-dashoffset: 0; }
+}
+
+.activity-chart__trend-head {
+  position: absolute;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: rgb(var(--v-theme-on-surface));
+  box-shadow: 0 0 0 3px rgba(var(--v-theme-surface), 1), 0 0 8px rgba(var(--v-theme-on-surface), 0.5);
+  pointer-events: none;
+  animation: gd-fade-in 300ms ease-out 1100ms both;
+}
+
 .activity-chart__hit {
   fill: transparent;
   cursor: pointer;
@@ -367,11 +543,33 @@ const tooltipStyle = computed(() => {
   margin-top: 4px;
 }
 
+.activity-chart__axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 6px;
+  padding: 0 2px;
+  font-size: 0.6875rem;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  font-variant-numeric: tabular-nums;
+}
+
+.activity-chart__axis-today {
+  color: rgba(var(--v-theme-on-surface), 0.7);
+  font-weight: 600;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .activity-chart__seg {
     transition: none;
   }
   .activity-chart__col {
+    animation: none;
+  }
+  .activity-chart__trend {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+  .activity-chart__trend-head {
     animation: none;
   }
 }

--- a/ui/src/components/stats/ActivityChart.vue
+++ b/ui/src/components/stats/ActivityChart.vue
@@ -7,6 +7,17 @@
       role="img"
       :aria-label="ariaLabel"
     >
+      <defs>
+        <linearGradient :id="gradTextId" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" class="activity-chart__grad-text-top" />
+          <stop offset="1" class="activity-chart__grad-text-bot" />
+        </linearGradient>
+        <linearGradient :id="gradFileId" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" class="activity-chart__grad-file-top" />
+          <stop offset="1" class="activity-chart__grad-file-bot" />
+        </linearGradient>
+      </defs>
+
       <!-- gridlines -->
       <g class="activity-chart__grid">
         <line
@@ -30,37 +41,43 @@
 
       <!-- columns -->
       <g v-for="(day, i) in daily" :key="day.date || i">
-        <template v-if="!isEmpty">
+        <g
+          class="activity-chart__col"
+          :class="{ 'activity-chart__col--hover': hoveredIndex === i }"
+          :style="colStyle(i)"
+        >
+          <template v-if="!isEmpty">
+            <path
+              v-if="segmentHeight(day, 'files') > 0"
+              :d="topRectPath(
+                slotX(i) + colOffset(i),
+                yForValue(day.texts || 0) - segmentHeight(day, 'files') - (segmentHeight(day, 'texts') > 0 ? gap : 0),
+                colWidth(i),
+                segmentHeight(day, 'files'),
+                4
+              )"
+              class="activity-chart__seg activity-chart__seg--file"
+              :class="{ 'activity-chart__seg--hover': hoveredIndex === i }"
+            />
+            <path
+              v-if="segmentHeight(day, 'texts') > 0"
+              :d="topRectPath(
+                slotX(i) + colOffset(i),
+                baselineY - segmentHeight(day, 'texts'),
+                colWidth(i),
+                segmentHeight(day, 'texts'),
+                segmentHeight(day, 'files') > 0 ? 0 : 4
+              )"
+              class="activity-chart__seg activity-chart__seg--text"
+              :class="{ 'activity-chart__seg--hover': hoveredIndex === i }"
+            />
+          </template>
           <path
-            v-if="segmentHeight(day, 'files') > 0"
-            :d="topRectPath(
-              slotX(i) + colOffset(i),
-              yForValue(day.texts || 0) - segmentHeight(day, 'files') - (segmentHeight(day, 'texts') > 0 ? gap : 0),
-              colWidth(i),
-              segmentHeight(day, 'files'),
-              4
-            )"
-            class="activity-chart__seg activity-chart__seg--file"
-            :class="{ 'activity-chart__seg--hover': hoveredIndex === i }"
+            v-else
+            :d="topRectPath(slotX(i) + colOffset(i), baselineY - ghostHeight(i), colWidth(i), ghostHeight(i), 4)"
+            class="activity-chart__seg activity-chart__seg--ghost"
           />
-          <path
-            v-if="segmentHeight(day, 'texts') > 0"
-            :d="topRectPath(
-              slotX(i) + colOffset(i),
-              baselineY - segmentHeight(day, 'texts'),
-              colWidth(i),
-              segmentHeight(day, 'texts'),
-              segmentHeight(day, 'files') > 0 ? 0 : 4
-            )"
-            class="activity-chart__seg activity-chart__seg--text"
-            :class="{ 'activity-chart__seg--hover': hoveredIndex === i }"
-          />
-        </template>
-        <path
-          v-else
-          :d="topRectPath(slotX(i) + colOffset(i), baselineY - ghostHeight(i), colWidth(i), ghostHeight(i), 4)"
-          class="activity-chart__seg activity-chart__seg--ghost"
-        />
+        </g>
 
         <!-- hit target: full slot band, full plot height -->
         <rect
@@ -101,6 +118,16 @@ const props = defineProps({
 
 const wrapRef = ref(null);
 const hoveredIndex = ref(null);
+
+// Namespaced gradient ids so the defs never clash with anything else on the page.
+const gradTextId = 'activity-chart-grad-text';
+const gradFileId = 'activity-chart-grad-file';
+
+// Staggered rise: each column starts a beat after the previous so the row
+// unfurls left-to-right. Capped so a long history never drags the reveal out.
+function colStyle(i) {
+  return { animationDelay: `${Math.min(i * 22, 420)}ms` };
+}
 
 const viewBoxWidth = 600;
 const viewBoxHeight = 150;
@@ -267,12 +294,20 @@ const tooltipStyle = computed(() => {
   fill: rgba(var(--v-theme-on-surface), 0.5);
 }
 
+/* Vertical gradients: saturated at the top edge, softening toward the
+   baseline so each bar reads as rising out of the ground. Theme-driven, so
+   they flip with light/dark automatically. */
+.activity-chart__grad-text-top { stop-color: rgb(var(--v-theme-chart-text)); stop-opacity: 1; }
+.activity-chart__grad-text-bot { stop-color: rgb(var(--v-theme-chart-text)); stop-opacity: 0.5; }
+.activity-chart__grad-file-top { stop-color: rgb(var(--v-theme-chart-file)); stop-opacity: 1; }
+.activity-chart__grad-file-bot { stop-color: rgb(var(--v-theme-chart-file)); stop-opacity: 0.5; }
+
 .activity-chart__seg--text {
-  fill: rgb(var(--v-theme-chart-text));
+  fill: url(#activity-chart-grad-text);
 }
 
 .activity-chart__seg--file {
-  fill: rgb(var(--v-theme-chart-file));
+  fill: url(#activity-chart-grad-file);
 }
 
 .activity-chart__seg--ghost {
@@ -284,7 +319,20 @@ const tooltipStyle = computed(() => {
 }
 
 .activity-chart__seg--hover {
-  opacity: 0.85;
+  opacity: 1;
+}
+
+/* Each column grows up from the baseline; the per-column delay is set inline
+   so the row unfurls left-to-right. transform-box keeps the origin pinned to
+   the group's own bottom edge regardless of the non-uniform viewBox scaling. */
+.activity-chart__col {
+  transform-box: fill-box;
+  transform-origin: bottom;
+  animation: gd-bar-grow 560ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.activity-chart__col--hover {
+  filter: drop-shadow(0 0 5px rgba(var(--v-theme-chart-text), 0.45));
 }
 
 .activity-chart__hit {
@@ -322,6 +370,9 @@ const tooltipStyle = computed(() => {
 @media (prefers-reduced-motion: reduce) {
   .activity-chart__seg {
     transition: none;
+  }
+  .activity-chart__col {
+    animation: none;
   }
 }
 </style>

--- a/ui/src/components/stats/MilestoneMeter.vue
+++ b/ui/src/components/stats/MilestoneMeter.vue
@@ -7,6 +7,12 @@
       role="img"
       :aria-label="ariaLabel"
     >
+      <defs>
+        <linearGradient id="milestone-meter-grad" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0" class="milestone-meter__grad-start" />
+          <stop offset="1" class="milestone-meter__grad-end" />
+        </linearGradient>
+      </defs>
       <path :d="trackPath" class="milestone-meter__track" />
       <path v-if="progress > 0" :d="fillPath" class="milestone-meter__fill" />
     </svg>
@@ -100,8 +106,21 @@ const fillPath = computed(() => {
   fill: rgba(var(--v-theme-primary), 0.16);
 }
 
+.milestone-meter__grad-start { stop-color: rgb(var(--v-theme-primary)); stop-opacity: 0.65; }
+.milestone-meter__grad-end { stop-color: rgb(var(--v-theme-primary)); stop-opacity: 1; }
+
 .milestone-meter__fill {
-  fill: rgb(var(--v-theme-primary));
+  fill: url(#milestone-meter-grad);
+  transform-box: fill-box;
+  transform-origin: left;
+  animation: gd-fill-x 700ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: 240ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .milestone-meter__fill {
+    animation: none;
+  }
 }
 
 .milestone-meter__caption {

--- a/ui/src/components/stats/MilestoneMeter.vue
+++ b/ui/src/components/stats/MilestoneMeter.vue
@@ -1,23 +1,36 @@
 <template>
   <div class="milestone-meter">
-    <svg
-      class="milestone-meter__svg"
-      viewBox="0 0 200 8"
-      preserveAspectRatio="none"
-      role="img"
-      :aria-label="ariaLabel"
-    >
-      <defs>
-        <linearGradient id="milestone-meter-grad" x1="0" y1="0" x2="1" y2="0">
-          <stop offset="0" class="milestone-meter__grad-start" />
-          <stop offset="1" class="milestone-meter__grad-end" />
-        </linearGradient>
-      </defs>
-      <path :d="trackPath" class="milestone-meter__track" />
-      <path v-if="progress > 0" :d="fillPath" class="milestone-meter__fill" />
-    </svg>
+    <div class="milestone-meter__bar">
+      <svg
+        class="milestone-meter__svg"
+        viewBox="0 0 200 8"
+        preserveAspectRatio="none"
+        role="img"
+        :aria-label="ariaLabel"
+      >
+        <defs>
+          <linearGradient id="milestone-meter-grad" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0" class="milestone-meter__grad-start" />
+            <stop offset="1" class="milestone-meter__grad-end" />
+          </linearGradient>
+        </defs>
+        <path :d="trackPath" class="milestone-meter__track" />
+        <path v-if="progress > 0" :d="fillPath" class="milestone-meter__fill" />
+      </svg>
 
-    <div class="milestone-meter__caption">{{ caption }}</div>
+      <span
+        v-if="showPip"
+        class="milestone-meter__pip"
+        :style="{ left: `${progress * 100}%` }"
+        aria-hidden="true"
+      ></span>
+    </div>
+
+    <div class="milestone-meter__scale">
+      <span class="milestone-meter__rung">{{ startLabel }}</span>
+      <span class="milestone-meter__caption">{{ caption }}</span>
+      <span class="milestone-meter__rung">{{ endLabel }}</span>
+    </div>
   </div>
 </template>
 
@@ -67,6 +80,15 @@ const caption = computed(() => {
 
 const ariaLabel = computed(() => `Milestone progress: ${caption.value}`);
 
+// Scale endpoints flanking the bar, so progress reads against a known span:
+// the last milestone cleared on the left, the one being chased on the right.
+const startLabel = computed(() => compactNumber(rungs.value.prev));
+const endLabel = computed(() => (rungs.value.maxed ? '∞' : compactNumber(rungs.value.next)));
+
+// The pip marks the current position; hide it once the bar is full (maxed) or
+// empty, where it would just sit on an endpoint.
+const showPip = computed(() => progress.value > 0 && progress.value < 1);
+
 /** Full rounded pill covering [x, x+width]. */
 function pillPath(x, width) {
   const r = Math.min(radius, width / 2, barHeight / 2);
@@ -92,7 +114,12 @@ const fillPath = computed(() => {
 .milestone-meter {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
+  width: 100%;
+}
+
+.milestone-meter__bar {
+  position: relative;
   width: 100%;
 }
 
@@ -100,6 +127,36 @@ const fillPath = computed(() => {
   width: 100%;
   height: 8px;
   display: block;
+}
+
+/* "You are here" node at the fill head — a bright dot with a soft primary halo,
+   revealed once the fill has swept out to it. */
+.milestone-meter__pip {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  background: rgb(var(--v-theme-primary));
+  box-shadow: 0 0 0 2px rgba(var(--v-theme-surface), 1), 0 0 10px rgba(var(--v-theme-primary), 0.7);
+  pointer-events: none;
+  animation: gd-fade-in 300ms ease-out 720ms both;
+}
+
+.milestone-meter__scale {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.milestone-meter__rung {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: rgba(var(--v-theme-on-surface), 0.45);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
 }
 
 .milestone-meter__track {
@@ -126,5 +183,13 @@ const fillPath = computed(() => {
 .milestone-meter__caption {
   font-size: 0.75rem;
   color: rgba(var(--v-theme-on-surface), 0.6);
+  text-align: center;
+  flex: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .milestone-meter__pip {
+    animation: none;
+  }
 }
 </style>

--- a/ui/src/components/stats/ServerLedger.vue
+++ b/ui/src/components/stats/ServerLedger.vue
@@ -23,17 +23,17 @@
     <v-divider class="server-ledger__divider" />
 
     <div class="server-ledger__grid">
-      <StatTile label="Text secrets" :value="local.texts" swatch="text" />
-      <StatTile label="Files shared" :value="local.files" swatch="file" />
-      <StatTile label="Data encrypted" :value="local.bytes" format="bytes" />
-      <StatTile label="Held right now" :value="local.active" caption="awaiting pickup" />
+      <StatTile class="gd-rise gd-rise--1" label="Text secrets" :value="local.texts" swatch="text" />
+      <StatTile class="gd-rise gd-rise--2" label="Files shared" :value="local.files" swatch="file" />
+      <StatTile class="gd-rise gd-rise--3" label="Data encrypted" :value="local.bytes" format="bytes" />
+      <StatTile class="gd-rise gd-rise--4" label="Held right now" :value="local.active" caption="awaiting pickup" live />
     </div>
 
-    <SplitBar :texts="local.texts" :files="local.files" class="server-ledger__section" />
+    <SplitBar :texts="local.texts" :files="local.files" class="server-ledger__section gd-fade-in" />
 
-    <ActivityChart :daily="local.daily" class="server-ledger__section" />
+    <ActivityChart :daily="local.daily" class="server-ledger__section gd-fade-in" />
 
-    <MilestoneMeter :total="local.total" class="server-ledger__section" />
+    <MilestoneMeter :total="local.total" class="server-ledger__section gd-fade-in" />
   </div>
 
   <!-- error/null: render nothing so the form column can center itself -->

--- a/ui/src/components/stats/SplitBar.vue
+++ b/ui/src/components/stats/SplitBar.vue
@@ -1,8 +1,18 @@
 <template>
   <div class="split-bar">
     <div class="split-bar__labels">
-      <span class="split-bar__label">Text {{ textPercent }}%</span>
-      <span class="split-bar__label">Files {{ filePercent }}%</span>
+      <span class="split-bar__label">
+        <span class="split-bar__dot split-bar__dot--text" aria-hidden="true"></span>
+        Text
+        <span class="split-bar__count">{{ compactNumber(texts) }}</span>
+        <span class="split-bar__pct">{{ textPercent }}%</span>
+      </span>
+      <span class="split-bar__label">
+        <span class="split-bar__pct">{{ filePercent }}%</span>
+        <span class="split-bar__count">{{ compactNumber(files) }}</span>
+        Files
+        <span class="split-bar__dot split-bar__dot--file" aria-hidden="true"></span>
+      </span>
     </div>
 
     <svg
@@ -50,6 +60,7 @@
 
 <script setup>
 import { computed } from 'vue';
+import { compactNumber } from '../../utils/format.js';
 
 const props = defineProps({
   texts: { type: Number, default: 0 },
@@ -117,7 +128,33 @@ const filePath = computed(() =>
   display: flex;
   justify-content: space-between;
   font-size: 0.75rem;
-  color: rgba(var(--v-theme-on-surface), 0.87);
+  color: rgba(var(--v-theme-on-surface), 0.7);
+}
+
+.split-bar__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.split-bar__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.split-bar__dot--text { background: rgb(var(--v-theme-chart-text)); }
+.split-bar__dot--file { background: rgb(var(--v-theme-chart-file)); }
+
+.split-bar__count {
+  font-weight: 600;
+  color: rgb(var(--v-theme-on-surface));
+  font-variant-numeric: tabular-nums;
+}
+
+.split-bar__pct {
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  font-variant-numeric: tabular-nums;
 }
 
 .split-bar__svg {

--- a/ui/src/components/stats/SplitBar.vue
+++ b/ui/src/components/stats/SplitBar.vue
@@ -12,6 +12,17 @@
       role="img"
       :aria-label="`Text ${textPercent}%, Files ${filePercent}%`"
     >
+      <defs>
+        <linearGradient id="split-bar-grad-text" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" class="split-bar__grad-text-top" />
+          <stop offset="1" class="split-bar__grad-text-bot" />
+        </linearGradient>
+        <linearGradient id="split-bar-grad-file" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" class="split-bar__grad-file-top" />
+          <stop offset="1" class="split-bar__grad-file-bot" />
+        </linearGradient>
+      </defs>
+
       <rect
         v-if="total === 0"
         x="0"
@@ -21,7 +32,7 @@
         rx="6"
         class="split-bar__track"
       />
-      <template v-else>
+      <g v-else class="split-bar__fill">
         <path
           v-if="textWidth > 0"
           :d="textPath"
@@ -32,7 +43,7 @@
           :d="filePath"
           class="split-bar__seg split-bar__seg--file"
         />
-      </template>
+      </g>
     </svg>
   </div>
 </template>
@@ -119,11 +130,30 @@ const filePath = computed(() =>
   fill: rgba(var(--v-theme-on-surface), 0.08);
 }
 
+.split-bar__grad-text-top { stop-color: rgb(var(--v-theme-chart-text)); stop-opacity: 1; }
+.split-bar__grad-text-bot { stop-color: rgb(var(--v-theme-chart-text)); stop-opacity: 0.72; }
+.split-bar__grad-file-top { stop-color: rgb(var(--v-theme-chart-file)); stop-opacity: 1; }
+.split-bar__grad-file-bot { stop-color: rgb(var(--v-theme-chart-file)); stop-opacity: 0.72; }
+
 .split-bar__seg--text {
-  fill: rgb(var(--v-theme-chart-text));
+  fill: url(#split-bar-grad-text);
 }
 
 .split-bar__seg--file {
-  fill: rgb(var(--v-theme-chart-file));
+  fill: url(#split-bar-grad-file);
+}
+
+/* Sweep the ratio in from the left on reveal. */
+.split-bar__fill {
+  transform-box: fill-box;
+  transform-origin: left;
+  animation: gd-fill-x 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: 120ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .split-bar__fill {
+    animation: none;
+  }
 }
 </style>

--- a/ui/src/components/stats/StatTile.vue
+++ b/ui/src/components/stats/StatTile.vue
@@ -7,6 +7,11 @@
         :class="`stat-tile__swatch--${swatch}`"
         aria-hidden="true"
       />
+      <span
+        v-if="live"
+        class="stat-tile__live"
+        aria-hidden="true"
+      />
       <span class="stat-tile__label">{{ label }}</span>
     </div>
 
@@ -32,6 +37,7 @@ const props = defineProps({
   caption: { type: String, default: null },
   hero: { type: Boolean, default: false },
   swatch: { type: String, default: null }, // "text" | "file" | null
+  live: { type: Boolean, default: false }, // renders a breathing "live" dot
   format: { type: String, default: 'number' }, // "number" | "bytes"
 });
 
@@ -70,6 +76,33 @@ const displayValue = computed(() => {
 
 .stat-tile__swatch--file {
   background-color: rgb(var(--v-theme-chart-file));
+}
+
+/* Live indicator: a solid dot wrapped in a slow breathing ring, marking a
+   figure that reflects what the server is holding at this very moment. */
+.stat-tile__live {
+  position: relative;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background-color: rgb(var(--v-theme-chart-file));
+}
+
+.stat-tile__live::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background-color: rgb(var(--v-theme-chart-file));
+  animation: gd-pulse 2.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-tile__live::after {
+    animation: none;
+    opacity: 0;
+  }
 }
 
 .stat-tile__label {

--- a/ui/src/pages/Create.vue
+++ b/ui/src/pages/Create.vue
@@ -279,6 +279,17 @@ async function handleSubmit() {
   line-height: 1.2;
   text-align: left;
   margin: 0;
+  /* The word itself carries the brand: on-surface ink drifting into primary,
+     so "secret" is where the purple lands. */
+  background: linear-gradient(
+    100deg,
+    rgb(var(--v-theme-on-surface)) 35%,
+    rgb(var(--v-theme-primary)) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 
 @media (min-width: 960px) {
@@ -344,9 +355,13 @@ async function handleSubmit() {
   box-shadow: none;
 }
 
+.gd-secret-well :deep(.v-field) {
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
 .gd-secret-well :deep(.v-field.v-field--focused) {
   border: 1.5px solid rgb(var(--v-theme-primary));
-  box-shadow: none;
+  box-shadow: 0 0 0 3px rgba(var(--v-theme-primary), 0.12);
 }
 
 .gd-secret-well :deep(textarea) {
@@ -402,5 +417,26 @@ async function handleSubmit() {
 .create-page__submit {
   margin-top: 24px;
   border-radius: 10px;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.create-page__submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 26px rgba(var(--v-theme-primary), 0.32);
+}
+
+.create-page__submit:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 12px rgba(var(--v-theme-primary), 0.28);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .create-page__submit {
+    transition: none;
+  }
+  .create-page__submit:hover,
+  .create-page__submit:active {
+    transform: none;
+  }
 }
 </style>


### PR DESCRIPTION
Polishes the landing page and reworks the three server-ledger charts so the right-hand column both *moves* and *means* more. Pure presentation — no changes to form submission, stats fetching, or the live `tick()` path. Everything is theme-aware (drives off the existing `chart-text` / `chart-file` / `primary` tokens) and fully gated behind `prefers-reduced-motion`.

## 🔎 Live preview
A faithful, clickable preview (same SVG geometry + CSS as the components, using the current screenshot's numbers) — toggle light/dark and hit **Replay** to re-watch the load sequence:

**https://claude.ai/code/artifact/8b113892-f2f8-4b21-a863-602e8359095e**

## The ledger materializes on load
Instead of appearing flat and instant, the column plays one orchestrated sequence:

- **Stat tiles** stagger in; numbers count up (existing). The **"Held right now"** tile gains a slow breathing *live* dot for what the server is holding this moment.
- **Split bar** and **milestone meter** sweep in from the left, timed to follow the bars.
- **Activity bars** grow up from the baseline in a left-to-right cascade, with gradient fills (saturated at the top edge, softening toward the ground) and a soft drop-shadow glow on hover.

## Charts now carry meaning, not just motion
- **Activity chart** — a header summarising the period (total volume + busiest day); a **7-day trailing-average momentum line** that draws itself in over the bars, so a run of busy days reads as a rising trend; an emphasised **today** column with a marker dot on the trend head; and a **dated x-axis** (first day → Today) so the span is legible.
- **Split bar** — shows the real **text/file counts** alongside the percentages, each with its colour dot, so the ratio is quantitative rather than only relative.
- **Milestone meter** — flanks the bar with its **scale** (last milestone cleared → the one being chased) and drops a glowing **"you are here" pip** at the fill head, so progress reads against a known span.

## Landing touches
- Hero word carries a subtle on-surface→primary gradient (the purple lands on "secret").
- The secret well gets a soft focus ring; the submit button lifts on hover.

## Notes on verification
`npm run build` passes. The ledger needs the Go backend's `/stats` data and there's no browser in my environment to screenshot, so I verified via the build + the linked preview (which ports the identical geometry and CSS). Worth a local `npm run dev` against the backend before merge to confirm in-app.

## Commits
- `fix(ui)`: (already merged in #24) — context only
- `feat(ui)`: animate the server ledger and polish the landing page
- `feat(ui)`: make the ledger charts more meaningful